### PR TITLE
Add embedded ghostty theme support via config [theme] section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ initial_height = 600
 [fonts]
 families = [{ nerdfont = "JetBrainsMono" }]
 
+[theme]
+path = "themes/dracula"
+
 [ghostty]
 font-size = 14
 ```
@@ -169,6 +172,18 @@ env_file = ".env"
 variables = { MY_VAR = "value" }
 ```
 
+### `[theme]` -- optional
+
+Inline a local Ghostty theme file into the generated `ghostty.conf`. Relative
+paths are resolved from the directory containing `trolley.toml`. This is the
+portable way to ship a theme with your app, because it does not depend on
+Ghostty's external theme catalog being installed on the target machine.
+
+```toml
+[theme]
+path = "themes/dracula"
+```
+
 ### `[ghostty]` -- optional
 
 Pass-through configuration for the Ghostty terminal engine. Accepts any
@@ -176,11 +191,12 @@ Ghostty config key with a scalar value (string, integer, float, or boolean)
 or an array of scalars. Arrays are expanded into repeated key lines, which is
 how Ghostty handles multi-value options like `keybind`.
 Note that configs meant for Ghostty's GUI will not take effect (obviously).
+If you want to ship a theme file with your app, prefer `[theme]` over setting
+`theme = "..."` here.
 
 ```toml
 [ghostty]
 font-size = 14
-theme = "dracula"
 keybind = [
     "ctrl+==increase_font_size:1",
     "ctrl+-=decrease_font_size:1",

--- a/cli/src/commands/common.rs
+++ b/cli/src/commands/common.rs
@@ -544,7 +544,22 @@ pub fn assemble_config(
         buf.write_all(b"\n")?;
     }
 
-    // 3. Developer's ghostty.conf (optional)
+    // 3. Project theme file (optional) — inlined so packaged apps do not
+    // depend on Ghostty's external theme catalog being present.
+    if let Some(theme) = &config.theme {
+        let theme_path = PathBuf::from(&theme.path);
+        let theme_path = if theme_path.is_absolute() {
+            theme_path
+        } else {
+            project_dir.join(theme_path)
+        };
+        let content = std::fs::read(&theme_path)
+            .with_context(|| format!("reading theme file {}", theme_path.display()))?;
+        buf.write_all(&content)?;
+        buf.write_all(b"\n")?;
+    }
+
+    // 4. Developer's ghostty.conf (optional)
     let dev_config = project_dir.join(GHOSTTY_CONFIG_FILENAME);
     if dev_config.exists() {
         let content = std::fs::read(&dev_config)
@@ -553,14 +568,14 @@ pub fn assemble_config(
         buf.write_all(b"\n")?;
     }
 
-    // 4. [ghostty] section from manifest (overrides ghostty.conf)
+    // 5. [ghostty] section from manifest (overrides theme and ghostty.conf)
     let ghostty_config = trolley_config::ghostty_config_string(config);
     if !ghostty_config.is_empty() {
         buf.write_all(ghostty_config.as_bytes())?;
         buf.write_all(b"\n")?;
     }
 
-    // 5. Command to run the TUI binary, unless explicitly overridden.
+    // 6. Command to run the TUI binary, unless explicitly overridden.
     // Some apps need custom Ghostty startup semantics (for example `shell:`
     // commands paired with explicit working-directory behavior), so a manifest
     // `command` must take precedence over this default.
@@ -577,7 +592,7 @@ pub fn assemble_config(
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
-    use trolley_config::{App, Arch, Environment, Fonts, Gui, Linux};
+    use trolley_config::{App, Arch, Environment, Fonts, Gui, Linux, Theme};
 
     fn test_manifest() -> Config {
         Config {
@@ -597,6 +612,7 @@ mod tests {
             fonts: Fonts::default(),
             gui: Gui::default(),
             environment: Environment::default(),
+            theme: None,
             ghostty: BTreeMap::new(),
         }
     }
@@ -704,5 +720,33 @@ mod tests {
 
         assert!(rendered.contains("command = shell:./app_core\n"));
         assert!(!rendered.contains("command = direct:./app_core\n"));
+    }
+
+    #[test]
+    fn assemble_config_inlines_theme_file_before_manifest_overrides() {
+        let dir = tempfile::tempdir().unwrap();
+        let theme_dir = dir.path().join("themes");
+        std::fs::create_dir_all(&theme_dir).unwrap();
+        std::fs::write(
+            theme_dir.join("custom"),
+            "background = 000000\nforeground = ffffff\n",
+        )
+        .unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.theme = Some(Theme {
+            path: "themes/custom".into(),
+        });
+        manifest
+            .ghostty
+            .insert("background".into(), toml::Value::String("111111".into()));
+
+        let bytes = assemble_config(dir.path(), &manifest, "app_core", &[]).unwrap();
+        let rendered = String::from_utf8(bytes).unwrap();
+
+        let theme_idx = rendered.find("background = 000000\n").unwrap();
+        let override_idx = rendered.find("background = 111111\n").unwrap();
+        assert!(theme_idx < override_idx);
+        assert!(rendered.contains("foreground = ffffff\n"));
     }
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -64,6 +64,7 @@ pub fn run(path: Option<String>) -> Result<()> {
         fonts: Fonts::default(),
         gui: Gui::default(),
         environment: Environment::default(),
+        theme: None,
         ghostty: BTreeMap::new(),
     };
 
@@ -90,7 +91,14 @@ pub fn run(path: Option<String>) -> Result<()> {
         # env_file = \".env\"\n\
         # variables = { MY_VAR = \"value\" }\n";
 
-    let final_content = format!("{content}{fonts_block}{env_block}");
+    let theme_block = "\n\
+        # Inline a local Ghostty theme file into the generated ghostty.conf.\n\
+        # Useful when you want a packaged app theme without depending on\n\
+        # Ghostty's external theme catalog.\n\
+        # [theme]\n\
+        # path = \"themes/dracula\"\n";
+
+    let final_content = format!("{content}{fonts_block}{env_block}{theme_block}");
 
     std::fs::write(&manifest_path, &final_content)
         .with_context(|| format!("writing {}", manifest_path.display()))?;

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -304,6 +304,8 @@ pub struct Config {
     pub gui: Gui,
     #[serde(default, skip_serializing_if = "Environment::is_default")]
     pub environment: Environment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<Theme>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub ghostty: BTreeMap<String, toml::Value>,
 }
@@ -395,6 +397,12 @@ impl Environment {
     pub fn is_default(&self) -> bool {
         self.env_file.is_none() && self.variables.is_empty()
     }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Theme {
+    pub path: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -620,6 +628,18 @@ impl Config {
                         ));
                     }
                 }
+            }
+        }
+
+        if let Some(theme) = &self.theme {
+            if theme.path.trim().is_empty() {
+                errors.push("[theme] path must not be empty".into());
+            }
+            if self.ghostty.contains_key("theme") {
+                errors.push(
+                    "[theme] cannot be used together with [ghostty] theme; inline the theme via [theme] and keep [ghostty] for overrides"
+                        .into(),
+                );
             }
         }
 
@@ -886,6 +906,7 @@ mod tests {
             fonts: Fonts::default(),
             gui: Gui::default(),
             environment: Environment::default(),
+            theme: None,
             ghostty: BTreeMap::new(),
         }
     }
@@ -1103,6 +1124,7 @@ binaries = { aarch64 = "my-app-mac" }
         assert!(output.contains("linux")); // serialized as [linux.binaries] by toml
         assert!(!output.contains("macos"));
         assert!(!output.contains("windows"));
+        assert!(!output.contains("[theme]"));
         assert!(!output.contains("[ghostty]"));
         assert!(!output.contains("[window]"));
     }
@@ -1130,6 +1152,28 @@ binaries = { aarch64 = "my-app-mac" }
         assert!(output.contains("initial_width = 800"));
         assert!(output.contains("initial_height = 600"));
         assert!(!output.contains("resizable")); // None fields skipped
+    }
+
+    #[test]
+    fn theme_roundtrip() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[linux]
+binaries = { x86_64 = "my-app" }
+
+[theme]
+path = "themes/dracula"
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            manifest.theme.as_ref().map(|t| t.path.as_str()),
+            Some("themes/dracula")
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1394,6 +1438,26 @@ binaries = { x86_64 = "my-app" }
 "#;
         let manifest: Config = toml::from_str(toml_str).unwrap();
         assert!(manifest.environment.is_default());
+    }
+
+    #[test]
+    fn validate_theme_path_must_not_be_empty() {
+        let mut m = minimal_manifest();
+        m.theme = Some(Theme { path: "  ".into() });
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[theme] path must not be empty"));
+    }
+
+    #[test]
+    fn validate_theme_and_ghostty_theme_conflict() {
+        let mut m = minimal_manifest();
+        m.theme = Some(Theme {
+            path: "themes/dracula".into(),
+        });
+        m.ghostty
+            .insert("theme".into(), toml::Value::String("dracula".into()));
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[theme] cannot be used together with [ghostty] theme"));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
This PR adds support for an optional `[theme]` config section, and when `path = ...` is specified within the section, a Ghostty theme is embedded into the generated Ghostty config file. This allows for packaging of a theme without reliance on external Ghostty themes.