### PR TITLE
Add support for embedding a custom shader

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ initial_height = 600
 [fonts]
 families = [{ nerdfont = "JetBrainsMono" }]
 
+[shader]
+path = "shaders/crt.glsl"
+
 [ghostty]
 font-size = 14
 ```
@@ -169,6 +172,18 @@ env_file = ".env"
 variables = { MY_VAR = "value" }
 ```
 
+### `[shader]` -- optional
+
+Bundle a single custom shader file and wire it into Ghostty as a
+`custom-shader` entry. The path must be a clean relative path from the
+directory containing `trolley.toml`; Trolley copies the shader into the bundle
+at the same relative path so `trolley run` and packaged apps behave the same.
+
+```toml
+[shader]
+path = "shaders/crt.glsl"
+```
+
 ### `[ghostty]` -- optional
 
 Pass-through configuration for the Ghostty terminal engine. Accepts any
@@ -176,6 +191,8 @@ Ghostty config key with a scalar value (string, integer, float, or boolean)
 or an array of scalars. Arrays are expanded into repeated key lines, which is
 how Ghostty handles multi-value options like `keybind`.
 Note that configs meant for Ghostty's GUI will not take effect (obviously).
+If you want to bundle a shader with your app, prefer `[shader]` over setting
+`custom-shader` here.
 
 ```toml
 [ghostty]

--- a/cli/src/commands/common.rs
+++ b/cli/src/commands/common.rs
@@ -338,6 +338,45 @@ pub fn copy_fonts_to_bundle(font_files: &[PathBuf], output_dir: &Path) -> Result
     Ok(())
 }
 
+pub struct BundledShader {
+    pub relative_path: PathBuf,
+    pub absolute_path: PathBuf,
+}
+
+pub fn resolve_shader(project_dir: &Path, config: &Config) -> Result<Option<BundledShader>> {
+    let Some(shader) = &config.shader else {
+        return Ok(None);
+    };
+
+    let relative_path = PathBuf::from(&shader.path);
+    let absolute_path = project_dir.join(&relative_path);
+    let absolute_path = absolute_path
+        .canonicalize()
+        .with_context(|| format!("shader file not found at {}", absolute_path.display()))?;
+
+    Ok(Some(BundledShader {
+        relative_path,
+        absolute_path,
+    }))
+}
+
+pub fn copy_shader_to_bundle(shader: &BundledShader, output_dir: &Path) -> Result<()> {
+    let dest = output_dir.join(&shader.relative_path);
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating shader directory {}", parent.display()))?;
+    }
+    std::fs::copy(&shader.absolute_path, &dest).with_context(|| {
+        format!(
+            "copying shader {} to {}",
+            shader.absolute_path.display(),
+            dest.display()
+        )
+    })?;
+
+    Ok(())
+}
+
 const FONTCONFIG_TEMPLATE: &str = r#"<?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
@@ -553,14 +592,20 @@ pub fn assemble_config(
         buf.write_all(b"\n")?;
     }
 
-    // 4. [ghostty] section from manifest (overrides ghostty.conf)
+    // 4. Bundled custom shader path (optional)
+    if let Some(shader) = &config.shader {
+        write!(buf, "custom-shader = {}\n", shader.path)?;
+        buf.write_all(b"\n")?;
+    }
+
+    // 5. [ghostty] section from manifest (overrides ghostty.conf)
     let ghostty_config = trolley_config::ghostty_config_string(config);
     if !ghostty_config.is_empty() {
         buf.write_all(ghostty_config.as_bytes())?;
         buf.write_all(b"\n")?;
     }
 
-    // 5. Command to run the TUI binary, unless explicitly overridden.
+    // 6. Command to run the TUI binary, unless explicitly overridden.
     // Some apps need custom Ghostty startup semantics (for example `shell:`
     // commands paired with explicit working-directory behavior), so a manifest
     // `command` must take precedence over this default.
@@ -577,7 +622,7 @@ pub fn assemble_config(
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
-    use trolley_config::{App, Arch, Environment, Fonts, Gui, Linux};
+    use trolley_config::{App, Arch, Environment, Fonts, Gui, Linux, Shader};
 
     fn test_manifest() -> Config {
         Config {
@@ -597,6 +642,7 @@ mod tests {
             fonts: Fonts::default(),
             gui: Gui::default(),
             environment: Environment::default(),
+            shader: None,
             ghostty: BTreeMap::new(),
         }
     }
@@ -704,5 +750,55 @@ mod tests {
 
         assert!(rendered.contains("command = shell:./app_core\n"));
         assert!(!rendered.contains("command = direct:./app_core\n"));
+    }
+
+    #[test]
+    fn assemble_config_includes_custom_shader_when_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manifest = test_manifest();
+        manifest.shader = Some(Shader {
+            path: "shaders/crt.glsl".into(),
+        });
+
+        let bytes = assemble_config(dir.path(), &manifest, "app_core", &[]).unwrap();
+        let rendered = String::from_utf8(bytes).unwrap();
+
+        assert!(rendered.contains("custom-shader = shaders/crt.glsl\n"));
+    }
+
+    #[test]
+    fn resolve_shader_resolves_relative_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let shader_dir = dir.path().join("shaders");
+        std::fs::create_dir_all(&shader_dir).unwrap();
+        std::fs::write(shader_dir.join("crt.glsl"), "void mainImage() {}").unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.shader = Some(Shader {
+            path: "shaders/crt.glsl".into(),
+        });
+
+        let shader = resolve_shader(dir.path(), &manifest).unwrap().unwrap();
+        assert_eq!(shader.relative_path, PathBuf::from("shaders/crt.glsl"));
+        assert!(shader.absolute_path.is_absolute());
+    }
+
+    #[test]
+    fn copy_shader_to_bundle_preserves_relative_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_dir = tempfile::tempdir().unwrap();
+        let shader_dir = dir.path().join("shaders");
+        std::fs::create_dir_all(&shader_dir).unwrap();
+        std::fs::write(shader_dir.join("crt.glsl"), "void mainImage() {}").unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.shader = Some(Shader {
+            path: "shaders/crt.glsl".into(),
+        });
+
+        let shader = resolve_shader(dir.path(), &manifest).unwrap().unwrap();
+        copy_shader_to_bundle(&shader, bundle_dir.path()).unwrap();
+
+        assert!(bundle_dir.path().join("shaders/crt.glsl").exists());
     }
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -64,6 +64,7 @@ pub fn run(path: Option<String>) -> Result<()> {
         fonts: Fonts::default(),
         gui: Gui::default(),
         environment: Environment::default(),
+        shader: None,
         ghostty: BTreeMap::new(),
     };
 
@@ -90,7 +91,13 @@ pub fn run(path: Option<String>) -> Result<()> {
         # env_file = \".env\"\n\
         # variables = { MY_VAR = \"value\" }\n";
 
-    let final_content = format!("{content}{fonts_block}{env_block}");
+    let shader_block = "\n\
+        # Bundle a single custom shader and wire it into Ghostty as\n\
+        # `custom-shader = <path>` using the same relative path.\n\
+        # [shader]\n\
+        # path = \"shaders/crt.glsl\"\n";
+
+    let final_content = format!("{content}{fonts_block}{env_block}{shader_block}");
 
     std::fs::write(&manifest_path, &final_content)
         .with_context(|| format!("writing {}", manifest_path.display()))?;

--- a/cli/src/commands/package.rs
+++ b/cli/src/commands/package.rs
@@ -82,6 +82,12 @@ pub fn run(
 
     // Read font family names for config assembly
     let font_family_names = common::read_font_family_names(&font_files)?;
+    let shader = common::resolve_shader(&ctx.project_dir, &ctx.config)?;
+
+    if let Some(shader) = &shader {
+        common::copy_shader_to_bundle(shader, &bundle_dir)?;
+        manifest.resources.push(shader.relative_path.clone());
+    }
 
     // Assemble ghostty.conf — command references the renamed TUI binary
     let config_bytes = common::assemble_config(
@@ -152,6 +158,9 @@ pub fn run(
     }
     if !font_files.is_empty() {
         println!("  fonts/  ({} font files)", font_files.len());
+    }
+    if let Some(shader) = &shader {
+        println!("  {}  (custom shader)", shader.relative_path.display());
     }
 
     // Build packages unless bundle-only

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -304,6 +304,8 @@ pub struct Config {
     pub gui: Gui,
     #[serde(default, skip_serializing_if = "Environment::is_default")]
     pub environment: Environment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shader: Option<Shader>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub ghostty: BTreeMap<String, toml::Value>,
 }
@@ -395,6 +397,12 @@ impl Environment {
     pub fn is_default(&self) -> bool {
         self.env_file.is_none() && self.variables.is_empty()
     }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Shader {
+    pub path: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -620,6 +628,35 @@ impl Config {
                         ));
                     }
                 }
+            }
+        }
+
+        if let Some(shader) = &self.shader {
+            if shader.path.trim().is_empty() {
+                errors.push("[shader] path must not be empty".into());
+            } else {
+                let path = Path::new(&shader.path);
+                if path.is_absolute() {
+                    errors.push("[shader] path must be relative".into());
+                }
+                if path.components().any(|component| {
+                    matches!(
+                        component,
+                        std::path::Component::ParentDir
+                            | std::path::Component::CurDir
+                            | std::path::Component::RootDir
+                            | std::path::Component::Prefix(_)
+                    )
+                }) {
+                    errors.push(
+                        "[shader] path must be a clean relative path without '.' or '..' segments"
+                            .into(),
+                    );
+                }
+            }
+
+            if self.ghostty.contains_key("custom-shader") {
+                errors.push("[shader] cannot be used together with [ghostty] custom-shader".into());
             }
         }
 
@@ -886,6 +923,7 @@ mod tests {
             fonts: Fonts::default(),
             gui: Gui::default(),
             environment: Environment::default(),
+            shader: None,
             ghostty: BTreeMap::new(),
         }
     }
@@ -1103,6 +1141,7 @@ binaries = { aarch64 = "my-app-mac" }
         assert!(output.contains("linux")); // serialized as [linux.binaries] by toml
         assert!(!output.contains("macos"));
         assert!(!output.contains("windows"));
+        assert!(!output.contains("[shader]"));
         assert!(!output.contains("[ghostty]"));
         assert!(!output.contains("[window]"));
     }
@@ -1130,6 +1169,28 @@ binaries = { aarch64 = "my-app-mac" }
         assert!(output.contains("initial_width = 800"));
         assert!(output.contains("initial_height = 600"));
         assert!(!output.contains("resizable")); // None fields skipped
+    }
+
+    #[test]
+    fn shader_roundtrip() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[linux]
+binaries = { x86_64 = "my-app" }
+
+[shader]
+path = "shaders/crt.glsl"
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            manifest.shader.as_ref().map(|shader| shader.path.as_str()),
+            Some("shaders/crt.glsl")
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1394,6 +1455,48 @@ binaries = { x86_64 = "my-app" }
 "#;
         let manifest: Config = toml::from_str(toml_str).unwrap();
         assert!(manifest.environment.is_default());
+    }
+
+    #[test]
+    fn validate_shader_path_must_not_be_empty() {
+        let mut m = minimal_manifest();
+        m.shader = Some(Shader { path: " ".into() });
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[shader] path must not be empty"));
+    }
+
+    #[test]
+    fn validate_shader_path_must_be_relative() {
+        let mut m = minimal_manifest();
+        m.shader = Some(Shader {
+            path: "/tmp/crt.glsl".into(),
+        });
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[shader] path must be relative"));
+    }
+
+    #[test]
+    fn validate_shader_path_must_not_escape_bundle() {
+        let mut m = minimal_manifest();
+        m.shader = Some(Shader {
+            path: "../crt.glsl".into(),
+        });
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("clean relative path"));
+    }
+
+    #[test]
+    fn validate_shader_and_ghostty_custom_shader_conflict() {
+        let mut m = minimal_manifest();
+        m.shader = Some(Shader {
+            path: "shaders/crt.glsl".into(),
+        });
+        m.ghostty.insert(
+            "custom-shader".into(),
+            toml::Value::String("foo.glsl".into()),
+        );
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[shader] cannot be used together with [ghostty] custom-shader"));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
This PR adds support for an optional `[shader]` config section. When `path = ...` is set, a custom shader is embedded into the packaged application. 