### PR TITLE
Added [embeds], which supports an embeddable theme file, shaders, and data paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ initial_height = 600
 [fonts]
 families = [{ nerdfont = "JetBrainsMono" }]
 
+[embeds]
+theme = "themes/dracula"
+shaders = ["shaders/crt.glsl", "shaders/bloom.glsl"]
+data = ["assets", "config/defaults.json"]
+
 [ghostty]
 font-size = 14
 ```
@@ -169,6 +174,32 @@ env_file = ".env"
 variables = { MY_VAR = "value" }
 ```
 
+### `[embeds]` -- optional
+
+Embed portable Ghostty resources into the generated bundle. Relative paths are
+resolved from the directory containing `trolley.toml`.
+
+```toml
+[embeds]
+theme = "themes/dracula"
+shaders = ["shaders/crt.glsl", "shaders/bloom.glsl"]
+data = ["assets", "config/defaults.json"]
+```
+
+`theme` inlines a local Ghostty theme file into the generated `ghostty.conf`.
+This is the portable way to ship a theme with your app, because it does not
+depend on Ghostty's external theme catalog being installed on the target
+machine.
+
+`shaders` bundles one or more custom shader files and wires them into Ghostty
+as repeated `custom-shader` entries. Each shader path must be a clean relative
+path; Trolley copies every shader into the bundle at the same relative path so
+`trolley run` and packaged apps behave the same.
+
+`data` copies files or directories into the bundle root at the same
+relative paths. This is useful for application assets or default data files
+that your TUI loads relative to the runtime working directory.
+
 ### `[ghostty]` -- optional
 
 Pass-through configuration for the Ghostty terminal engine. Accepts any
@@ -176,11 +207,14 @@ Ghostty config key with a scalar value (string, integer, float, or boolean)
 or an array of scalars. Arrays are expanded into repeated key lines, which is
 how Ghostty handles multi-value options like `keybind`.
 Note that configs meant for Ghostty's GUI will not take effect (obviously).
+If you want to ship a theme file with your app, prefer `[embeds].theme` over setting
+`theme = "..."` here.
+If you want to bundle shaders with your app, prefer `[embeds].shaders` over setting
+`custom-shader` here.
 
 ```toml
 [ghostty]
 font-size = 14
-theme = "dracula"
 keybind = [
     "ctrl+==increase_font_size:1",
     "ctrl+-=decrease_font_size:1",

--- a/cli/src/commands/common.rs
+++ b/cli/src/commands/common.rs
@@ -338,17 +338,12 @@ pub fn copy_fonts_to_bundle(font_files: &[PathBuf], output_dir: &Path) -> Result
     Ok(())
 }
 
-pub struct BundledShader {
+pub struct BundledPath {
     pub relative_path: PathBuf,
     pub absolute_path: PathBuf,
 }
 
-pub struct BundledDataPath {
-    pub relative_path: PathBuf,
-    pub absolute_path: PathBuf,
-}
-
-pub fn resolve_shaders(project_dir: &Path, config: &Config) -> Result<Vec<BundledShader>> {
+pub fn resolve_shaders(project_dir: &Path, config: &Config) -> Result<Vec<BundledPath>> {
     config
         .embeds
         .shaders
@@ -360,7 +355,7 @@ pub fn resolve_shaders(project_dir: &Path, config: &Config) -> Result<Vec<Bundle
                 .canonicalize()
                 .with_context(|| format!("shader file not found at {}", absolute_path.display()))?;
 
-            Ok(BundledShader {
+            Ok(BundledPath {
                 relative_path,
                 absolute_path,
             })
@@ -368,7 +363,7 @@ pub fn resolve_shaders(project_dir: &Path, config: &Config) -> Result<Vec<Bundle
         .collect()
 }
 
-pub fn resolve_data_paths(project_dir: &Path, config: &Config) -> Result<Vec<BundledDataPath>> {
+pub fn resolve_data_paths(project_dir: &Path, config: &Config) -> Result<Vec<BundledPath>> {
     config
         .embeds
         .data
@@ -380,7 +375,7 @@ pub fn resolve_data_paths(project_dir: &Path, config: &Config) -> Result<Vec<Bun
                 .canonicalize()
                 .with_context(|| format!("data path not found at {}", absolute_path.display()))?;
 
-            Ok(BundledDataPath {
+            Ok(BundledPath {
                 relative_path,
                 absolute_path,
             })
@@ -388,7 +383,7 @@ pub fn resolve_data_paths(project_dir: &Path, config: &Config) -> Result<Vec<Bun
         .collect()
 }
 
-pub fn copy_shader_to_bundle(shader: &BundledShader, output_dir: &Path) -> Result<()> {
+pub fn copy_shader_to_bundle(shader: &BundledPath, output_dir: &Path) -> Result<()> {
     let dest = output_dir.join(&shader.relative_path);
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)
@@ -405,7 +400,7 @@ pub fn copy_shader_to_bundle(shader: &BundledShader, output_dir: &Path) -> Resul
     Ok(())
 }
 
-pub fn copy_data_path_to_bundle(data_path: &BundledDataPath, output_dir: &Path) -> Result<Vec<PathBuf>> {
+pub fn copy_data_path_to_bundle(data_path: &BundledPath, output_dir: &Path) -> Result<Vec<PathBuf>> {
     let dest = output_dir.join(&data_path.relative_path);
     if data_path.absolute_path.is_dir() {
         let mut copied_files = Vec::new();

--- a/cli/src/commands/common.rs
+++ b/cli/src/commands/common.rs
@@ -338,6 +338,138 @@ pub fn copy_fonts_to_bundle(font_files: &[PathBuf], output_dir: &Path) -> Result
     Ok(())
 }
 
+pub struct BundledShader {
+    pub relative_path: PathBuf,
+    pub absolute_path: PathBuf,
+}
+
+pub struct BundledDataPath {
+    pub relative_path: PathBuf,
+    pub absolute_path: PathBuf,
+}
+
+pub fn resolve_shaders(project_dir: &Path, config: &Config) -> Result<Vec<BundledShader>> {
+    config
+        .embeds
+        .shaders
+        .iter()
+        .map(|shader| {
+            let relative_path = PathBuf::from(shader);
+            let absolute_path = project_dir.join(&relative_path);
+            let absolute_path = absolute_path
+                .canonicalize()
+                .with_context(|| format!("shader file not found at {}", absolute_path.display()))?;
+
+            Ok(BundledShader {
+                relative_path,
+                absolute_path,
+            })
+        })
+        .collect()
+}
+
+pub fn resolve_data_paths(project_dir: &Path, config: &Config) -> Result<Vec<BundledDataPath>> {
+    config
+        .embeds
+        .data
+        .iter()
+        .map(|data_path| {
+            let relative_path = PathBuf::from(data_path);
+            let absolute_path = project_dir.join(&relative_path);
+            let absolute_path = absolute_path
+                .canonicalize()
+                .with_context(|| format!("data path not found at {}", absolute_path.display()))?;
+
+            Ok(BundledDataPath {
+                relative_path,
+                absolute_path,
+            })
+        })
+        .collect()
+}
+
+pub fn copy_shader_to_bundle(shader: &BundledShader, output_dir: &Path) -> Result<()> {
+    let dest = output_dir.join(&shader.relative_path);
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating shader directory {}", parent.display()))?;
+    }
+    std::fs::copy(&shader.absolute_path, &dest).with_context(|| {
+        format!(
+            "copying shader {} to {}",
+            shader.absolute_path.display(),
+            dest.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+pub fn copy_data_path_to_bundle(data_path: &BundledDataPath, output_dir: &Path) -> Result<Vec<PathBuf>> {
+    let dest = output_dir.join(&data_path.relative_path);
+    if data_path.absolute_path.is_dir() {
+        let mut copied_files = Vec::new();
+        copy_directory_contents(
+            &data_path.absolute_path,
+            &dest,
+            &data_path.relative_path,
+            &mut copied_files,
+        )?;
+        Ok(copied_files)
+    } else {
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating data directory {}", parent.display()))?;
+        }
+        std::fs::copy(&data_path.absolute_path, &dest).with_context(|| {
+            format!(
+                "copying data file {} to {}",
+                data_path.absolute_path.display(),
+                dest.display()
+            )
+        })?;
+        Ok(vec![data_path.relative_path.clone()])
+    }
+}
+
+fn copy_directory_contents(
+    src_dir: &Path,
+    dest_dir: &Path,
+    relative_root: &Path,
+    copied_files: &mut Vec<PathBuf>,
+) -> Result<()> {
+    std::fs::create_dir_all(dest_dir)
+        .with_context(|| format!("creating data directory {}", dest_dir.display()))?;
+
+    for entry in std::fs::read_dir(src_dir)
+        .with_context(|| format!("reading data directory {}", src_dir.display()))?
+    {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dest_path = dest_dir.join(entry.file_name());
+        let relative_path = relative_root.join(entry.file_name());
+
+        if src_path.is_dir() {
+            copy_directory_contents(&src_path, &dest_path, &relative_path, copied_files)?;
+        } else {
+            if let Some(parent) = dest_path.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating data directory {}", parent.display()))?;
+            }
+            std::fs::copy(&src_path, &dest_path).with_context(|| {
+                format!(
+                    "copying data file {} to {}",
+                    src_path.display(),
+                    dest_path.display()
+                )
+            })?;
+            copied_files.push(relative_path);
+        }
+    }
+
+    Ok(())
+}
+
 const FONTCONFIG_TEMPLATE: &str = r#"<?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
@@ -544,7 +676,22 @@ pub fn assemble_config(
         buf.write_all(b"\n")?;
     }
 
-    // 3. Developer's ghostty.conf (optional)
+    // 3. Project theme file (optional) — inlined so packaged apps do not
+    // depend on Ghostty's external theme catalog being present.
+    if let Some(theme) = &config.embeds.theme {
+        let theme_path = PathBuf::from(theme);
+        let theme_path = if theme_path.is_absolute() {
+            theme_path
+        } else {
+            project_dir.join(theme_path)
+        };
+        let content = std::fs::read(&theme_path)
+            .with_context(|| format!("reading theme file {}", theme_path.display()))?;
+        buf.write_all(&content)?;
+        buf.write_all(b"\n")?;
+    }
+
+    // 4. Developer's ghostty.conf (optional)
     let dev_config = project_dir.join(GHOSTTY_CONFIG_FILENAME);
     if dev_config.exists() {
         let content = std::fs::read(&dev_config)
@@ -553,14 +700,22 @@ pub fn assemble_config(
         buf.write_all(b"\n")?;
     }
 
-    // 4. [ghostty] section from manifest (overrides ghostty.conf)
+    // 5. Bundled custom shader paths (optional)
+    for shader in &config.embeds.shaders {
+        write!(buf, "custom-shader = {shader}\n")?;
+    }
+    if !config.embeds.shaders.is_empty() {
+        buf.write_all(b"\n")?;
+    }
+
+    // 6. [ghostty] section from manifest (overrides theme, shaders, and ghostty.conf)
     let ghostty_config = trolley_config::ghostty_config_string(config);
     if !ghostty_config.is_empty() {
         buf.write_all(ghostty_config.as_bytes())?;
         buf.write_all(b"\n")?;
     }
 
-    // 5. Command to run the TUI binary, unless explicitly overridden.
+    // 7. Command to run the TUI binary, unless explicitly overridden.
     // Some apps need custom Ghostty startup semantics (for example `shell:`
     // commands paired with explicit working-directory behavior), so a manifest
     // `command` must take precedence over this default.
@@ -577,7 +732,7 @@ pub fn assemble_config(
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
-    use trolley_config::{App, Arch, Environment, Fonts, Gui, Linux};
+    use trolley_config::{App, Arch, Embeds, Environment, Fonts, Gui, Linux};
 
     fn test_manifest() -> Config {
         Config {
@@ -597,6 +752,7 @@ mod tests {
             fonts: Fonts::default(),
             gui: Gui::default(),
             environment: Environment::default(),
+            embeds: Embeds::default(),
             ghostty: BTreeMap::new(),
         }
     }
@@ -704,5 +860,127 @@ mod tests {
 
         assert!(rendered.contains("command = shell:./app_core\n"));
         assert!(!rendered.contains("command = direct:./app_core\n"));
+    }
+
+    #[test]
+    fn assemble_config_inlines_theme_file_before_manifest_overrides() {
+        let dir = tempfile::tempdir().unwrap();
+        let theme_dir = dir.path().join("themes");
+        std::fs::create_dir_all(&theme_dir).unwrap();
+        std::fs::write(
+            theme_dir.join("custom"),
+            "background = 000000\nforeground = ffffff\n",
+        )
+        .unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.embeds.theme = Some("themes/custom".into());
+        manifest
+            .ghostty
+            .insert("background".into(), toml::Value::String("111111".into()));
+
+        let bytes = assemble_config(dir.path(), &manifest, "app_core", &[]).unwrap();
+        let rendered = String::from_utf8(bytes).unwrap();
+
+        let theme_idx = rendered.find("background = 000000\n").unwrap();
+        let override_idx = rendered.find("background = 111111\n").unwrap();
+        assert!(theme_idx < override_idx);
+        assert!(rendered.contains("foreground = ffffff\n"));
+    }
+
+    #[test]
+    fn assemble_config_includes_custom_shader_when_configured() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manifest = test_manifest();
+        manifest.embeds.shaders = vec!["shaders/crt.glsl".into(), "shaders/bloom.glsl".into()];
+
+        let bytes = assemble_config(dir.path(), &manifest, "app_core", &[]).unwrap();
+        let rendered = String::from_utf8(bytes).unwrap();
+        assert!(rendered.contains("custom-shader = shaders/crt.glsl\n"));
+        assert!(rendered.contains("custom-shader = shaders/bloom.glsl\n"));
+    }
+
+    #[test]
+    fn resolve_shaders_resolve_relative_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let shader_dir = dir.path().join("shaders");
+        std::fs::create_dir_all(&shader_dir).unwrap();
+        std::fs::write(shader_dir.join("crt.glsl"), "void mainImage() {}").unwrap();
+        std::fs::write(shader_dir.join("bloom.glsl"), "void mainImage() {}").unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.embeds.shaders = vec!["shaders/crt.glsl".into(), "shaders/bloom.glsl".into()];
+
+        let shaders = resolve_shaders(dir.path(), &manifest).unwrap();
+        assert_eq!(shaders.len(), 2);
+        assert_eq!(shaders[0].relative_path, PathBuf::from("shaders/crt.glsl"));
+        assert_eq!(shaders[1].relative_path, PathBuf::from("shaders/bloom.glsl"));
+        assert!(shaders.iter().all(|shader| shader.absolute_path.is_absolute()));
+    }
+
+    #[test]
+    fn copy_shader_to_bundle_preserves_relative_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_dir = tempfile::tempdir().unwrap();
+        let shader_dir = dir.path().join("shaders");
+        std::fs::create_dir_all(&shader_dir).unwrap();
+        std::fs::write(shader_dir.join("crt.glsl"), "void mainImage() {}").unwrap();
+        std::fs::write(shader_dir.join("bloom.glsl"), "void mainImage() {}").unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.embeds.shaders = vec!["shaders/crt.glsl".into(), "shaders/bloom.glsl".into()];
+
+        let shaders = resolve_shaders(dir.path(), &manifest).unwrap();
+        for shader in &shaders {
+            copy_shader_to_bundle(shader, bundle_dir.path()).unwrap();
+        }
+
+        assert!(bundle_dir.path().join("shaders/crt.glsl").exists());
+        assert!(bundle_dir.path().join("shaders/bloom.glsl").exists());
+    }
+
+    #[test]
+    fn resolve_data_paths_resolves_file_and_directory_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let assets_dir = dir.path().join("assets");
+        std::fs::create_dir_all(assets_dir.join("nested")).unwrap();
+        std::fs::write(assets_dir.join("nested/info.txt"), "hello").unwrap();
+        std::fs::create_dir_all(dir.path().join("config")).unwrap();
+        std::fs::write(dir.path().join("config/defaults.json"), "{}").unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.embeds.data = vec!["assets".into(), "config/defaults.json".into()];
+
+        let data_paths = resolve_data_paths(dir.path(), &manifest).unwrap();
+        assert_eq!(data_paths.len(), 2);
+        assert_eq!(data_paths[0].relative_path, PathBuf::from("assets"));
+        assert_eq!(data_paths[1].relative_path, PathBuf::from("config/defaults.json"));
+        assert!(data_paths[0].absolute_path.is_dir());
+        assert!(data_paths[1].absolute_path.is_file());
+    }
+
+    #[test]
+    fn copy_data_path_to_bundle_preserves_relative_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_dir = tempfile::tempdir().unwrap();
+        let assets_dir = dir.path().join("assets");
+        std::fs::create_dir_all(assets_dir.join("nested")).unwrap();
+        std::fs::write(assets_dir.join("nested/info.txt"), "hello").unwrap();
+        std::fs::create_dir_all(dir.path().join("config")).unwrap();
+        std::fs::write(dir.path().join("config/defaults.json"), "{}").unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.embeds.data = vec!["assets".into(), "config/defaults.json".into()];
+
+        let data_paths = resolve_data_paths(dir.path(), &manifest).unwrap();
+        let mut copied_files = Vec::new();
+        for data_path in &data_paths {
+            copied_files.extend(copy_data_path_to_bundle(data_path, bundle_dir.path()).unwrap());
+        }
+
+        assert!(bundle_dir.path().join("assets/nested/info.txt").exists());
+        assert!(bundle_dir.path().join("config/defaults.json").exists());
+        assert!(copied_files.contains(&PathBuf::from("assets/nested/info.txt")));
+        assert!(copied_files.contains(&PathBuf::from("config/defaults.json")));
     }
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -64,6 +64,7 @@ pub fn run(path: Option<String>) -> Result<()> {
         fonts: Fonts::default(),
         gui: Gui::default(),
         environment: Environment::default(),
+        embeds: trolley_config::Embeds::default(),
         ghostty: BTreeMap::new(),
     };
 
@@ -90,7 +91,17 @@ pub fn run(path: Option<String>) -> Result<()> {
         # env_file = \".env\"\n\
         # variables = { MY_VAR = \"value\" }\n";
 
-    let final_content = format!("{content}{fonts_block}{env_block}");
+    let embeds_block = "\n\
+        # Embed portable Ghostty resources into the generated bundle.\n\
+        # `theme` is inlined into ghostty.conf.\n\
+        # `shaders` emits repeated `custom-shader = <path>` entries.\n\
+        # `data` copies files or directories into the bundle root.\n\
+        # [embeds]\n\
+        # theme = \"themes/dracula\"\n\
+        # shaders = [\"shaders/crt.glsl\"]\n\
+        # data = [\"assets\", \"config/defaults.json\"]\n";
+
+    let final_content = format!("{content}{fonts_block}{env_block}{embeds_block}");
 
     std::fs::write(&manifest_path, &final_content)
         .with_context(|| format!("writing {}", manifest_path.display()))?;

--- a/cli/src/commands/package.rs
+++ b/cli/src/commands/package.rs
@@ -82,6 +82,18 @@ pub fn run(
 
     // Read font family names for config assembly
     let font_family_names = common::read_font_family_names(&font_files)?;
+    let shaders = common::resolve_shaders(&ctx.project_dir, &ctx.config)?;
+    let data_paths = common::resolve_data_paths(&ctx.project_dir, &ctx.config)?;
+
+    for shader in &shaders {
+        common::copy_shader_to_bundle(shader, &bundle_dir)?;
+        manifest.resources.push(shader.relative_path.clone());
+    }
+    for data_path in &data_paths {
+        manifest
+            .resources
+            .extend(common::copy_data_path_to_bundle(data_path, &bundle_dir)?);
+    }
 
     // Assemble ghostty.conf — command references the renamed TUI binary
     let config_bytes = common::assemble_config(
@@ -152,6 +164,12 @@ pub fn run(
     }
     if !font_files.is_empty() {
         println!("  fonts/  ({} font files)", font_files.len());
+    }
+    for shader in &shaders {
+        println!("  {}  (custom shader)", shader.relative_path.display());
+    }
+    for data_path in &data_paths {
+        println!("  {}  (embedded data)", data_path.relative_path.display());
     }
 
     // Build packages unless bundle-only

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -304,6 +304,8 @@ pub struct Config {
     pub gui: Gui,
     #[serde(default, skip_serializing_if = "Environment::is_default")]
     pub environment: Environment,
+    #[serde(default, skip_serializing_if = "Embeds::is_default")]
+    pub embeds: Embeds,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub ghostty: BTreeMap<String, toml::Value>,
 }
@@ -394,6 +396,23 @@ pub struct Environment {
 impl Environment {
     pub fn is_default(&self) -> bool {
         self.env_file.is_none() && self.variables.is_empty()
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Embeds {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shaders: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub data: Vec<String>,
+}
+
+impl Embeds {
+    pub fn is_default(&self) -> bool {
+        self.theme.is_none() && self.shaders.is_empty() && self.data.is_empty()
     }
 }
 
@@ -620,6 +639,74 @@ impl Config {
                         ));
                     }
                 }
+            }
+        }
+
+        if let Some(theme_path) = &self.embeds.theme {
+            if theme_path.trim().is_empty() {
+                errors.push("[embeds] theme must not be empty".into());
+            }
+            if self.ghostty.contains_key("theme") {
+                errors.push(
+                    "[embeds] theme cannot be used together with [ghostty] theme; inline the theme via [embeds] and keep [ghostty] for overrides"
+                        .into(),
+                );
+            }
+        }
+
+        for (index, shader_path) in self.embeds.shaders.iter().enumerate() {
+            if shader_path.trim().is_empty() {
+                errors.push(format!("[embeds] shaders[{index}] must not be empty"));
+                continue;
+            }
+
+            let path = Path::new(shader_path);
+            if path.is_absolute() {
+                errors.push(format!("[embeds] shaders[{index}] must be relative"));
+            }
+            if path.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::ParentDir
+                        | std::path::Component::CurDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_)
+                )
+            }) {
+                errors.push(format!(
+                    "[embeds] shaders[{index}] must be a clean relative path without '.' or '..' segments"
+                ));
+            }
+        }
+
+        if !self.embeds.shaders.is_empty() && self.ghostty.contains_key("custom-shader") {
+            errors.push(
+                "[embeds] shaders cannot be used together with [ghostty] custom-shader".into(),
+            );
+        }
+
+        for (index, data_path) in self.embeds.data.iter().enumerate() {
+            if data_path.trim().is_empty() {
+                errors.push(format!("[embeds] data[{index}] must not be empty"));
+                continue;
+            }
+
+            let path = Path::new(data_path);
+            if path.is_absolute() {
+                errors.push(format!("[embeds] data[{index}] must be relative"));
+            }
+            if path.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::ParentDir
+                        | std::path::Component::CurDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_)
+                )
+            }) {
+                errors.push(format!(
+                    "[embeds] data[{index}] must be a clean relative path without '.' or '..' segments"
+                ));
             }
         }
 
@@ -886,6 +973,11 @@ mod tests {
             fonts: Fonts::default(),
             gui: Gui::default(),
             environment: Environment::default(),
+            embeds: Embeds {
+                theme: None,
+                shaders: Vec::new(),
+                data: Vec::new(),
+            },
             ghostty: BTreeMap::new(),
         }
     }
@@ -1103,6 +1195,7 @@ binaries = { aarch64 = "my-app-mac" }
         assert!(output.contains("linux")); // serialized as [linux.binaries] by toml
         assert!(!output.contains("macos"));
         assert!(!output.contains("windows"));
+        assert!(!output.contains("[embeds]"));
         assert!(!output.contains("[ghostty]"));
         assert!(!output.contains("[window]"));
     }
@@ -1130,6 +1223,72 @@ binaries = { aarch64 = "my-app-mac" }
         assert!(output.contains("initial_width = 800"));
         assert!(output.contains("initial_height = 600"));
         assert!(!output.contains("resizable")); // None fields skipped
+    }
+
+    #[test]
+    fn embeds_theme_roundtrip() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[linux]
+binaries = { x86_64 = "my-app" }
+
+[embeds]
+theme = "themes/dracula"
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            manifest.embeds.theme.as_deref(),
+            Some("themes/dracula")
+        );
+    }
+
+    #[test]
+    fn embeds_shaders_roundtrip() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[linux]
+binaries = { x86_64 = "my-app" }
+
+[embeds]
+shaders = ["shaders/crt.glsl", "shaders/scanlines.glsl"]
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            manifest.embeds.shaders,
+            vec!["shaders/crt.glsl", "shaders/scanlines.glsl"]
+        );
+    }
+
+    #[test]
+    fn embeds_data_roundtrip() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[linux]
+binaries = { x86_64 = "my-app" }
+
+[embeds]
+data = ["assets", "config/defaults.json"]
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            manifest.embeds.data,
+            vec!["assets", "config/defaults.json"]
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1394,6 +1553,84 @@ binaries = { x86_64 = "my-app" }
 "#;
         let manifest: Config = toml::from_str(toml_str).unwrap();
         assert!(manifest.environment.is_default());
+    }
+
+    #[test]
+    fn validate_embeds_theme_must_not_be_empty() {
+        let mut m = minimal_manifest();
+        m.embeds.theme = Some("  ".into());
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[embeds] theme must not be empty"));
+    }
+
+    #[test]
+    fn validate_embeds_theme_and_ghostty_theme_conflict() {
+        let mut m = minimal_manifest();
+        m.embeds.theme = Some("themes/dracula".into());
+        m.ghostty
+            .insert("theme".into(), toml::Value::String("dracula".into()));
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[embeds] theme cannot be used together with [ghostty] theme"));
+    }
+
+    #[test]
+    fn validate_embeds_shaders_must_not_be_empty() {
+        let mut m = minimal_manifest();
+        m.embeds.shaders = vec![" ".into()];
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[embeds] shaders[0] must not be empty"));
+    }
+
+    #[test]
+    fn validate_embeds_shaders_must_be_relative() {
+        let mut m = minimal_manifest();
+        m.embeds.shaders = vec!["/tmp/crt.glsl".into()];
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[embeds] shaders[0] must be relative"));
+    }
+
+    #[test]
+    fn validate_embeds_shaders_must_not_escape_bundle() {
+        let mut m = minimal_manifest();
+        m.embeds.shaders = vec!["../crt.glsl".into()];
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("clean relative path"));
+    }
+
+    #[test]
+    fn validate_embeds_shaders_and_ghostty_custom_shader_conflict() {
+        let mut m = minimal_manifest();
+        m.embeds.shaders = vec!["shaders/crt.glsl".into()];
+        m.ghostty.insert(
+            "custom-shader".into(),
+            toml::Value::String("foo.glsl".into()),
+        );
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[embeds] shaders cannot be used together with [ghostty] custom-shader"));
+    }
+
+    #[test]
+    fn validate_embeds_data_must_not_be_empty() {
+        let mut m = minimal_manifest();
+        m.embeds.data = vec![" ".into()];
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[embeds] data[0] must not be empty"));
+    }
+
+    #[test]
+    fn validate_embeds_data_must_be_relative() {
+        let mut m = minimal_manifest();
+        m.embeds.data = vec!["/tmp/assets".into()];
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[embeds] data[0] must be relative"));
+    }
+
+    #[test]
+    fn validate_embeds_data_must_not_escape_bundle() {
+        let mut m = minimal_manifest();
+        m.embeds.data = vec!["../assets".into()];
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[embeds] data[0] must be a clean relative path"));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
This PR adds an `[embeds]` configuration that supports:
* `theme` - An embedded theme file that is written out to the ghostty config.
* `shaders` - One or more shader files that are written out to the ghostty config.
* `data` - One or more files/directories that are directly copied to the packaged application.