### PR TITLE
feat: add macos_titlebar_style and drag-and-drop support

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -336,6 +336,22 @@ pub struct Gui {
     pub max_width: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_height: Option<u32>,
+    /// macOS titlebar style. Defaults to "visible".
+    /// Supported values: "visible", "hidden", "transparent".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub macos_titlebar_style: Option<MacosTitlebarStyle>,
+}
+
+/// Controls the macOS titlebar appearance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MacosTitlebarStyle {
+    /// Normal titled window (default).
+    Visible,
+    /// Titlebar is transparent with hidden title text; traffic lights remain.
+    Hidden,
+    /// Titlebar background is transparent; title text still shown.
+    Transparent,
 }
 
 impl Gui {
@@ -347,6 +363,7 @@ impl Gui {
             && self.min_height.is_none()
             && self.max_width.is_none()
             && self.max_height.is_none()
+            && self.macos_titlebar_style.is_none()
     }
 }
 
@@ -773,6 +790,8 @@ pub struct TrolleyGuiConfig {
     pub max_width: u32,
     /// Maximum height in pixels. 0 = unset.
     pub max_height: u32,
+    /// macOS titlebar style. 0 = visible (default), 1 = hidden, 2 = transparent.
+    pub macos_titlebar_style: u8,
 }
 
 /// Load a trolley manifest and extract the window and environment configs.
@@ -808,6 +827,11 @@ pub unsafe extern "C" fn trolley_load_manifest(
         window_config.min_height = manifest.gui.min_height.unwrap_or(0);
         window_config.max_width = manifest.gui.max_width.unwrap_or(0);
         window_config.max_height = manifest.gui.max_height.unwrap_or(0);
+        window_config.macos_titlebar_style = match manifest.gui.macos_titlebar_style {
+            None | Some(MacosTitlebarStyle::Visible) => 0,
+            Some(MacosTitlebarStyle::Hidden) => 1,
+            Some(MacosTitlebarStyle::Transparent) => 2,
+        };
 
         // Report ghostty config length so the caller can allocate.
         let config_string = ghostty_config_string(&manifest);

--- a/runtime/macos/Sources/main.swift
+++ b/runtime/macos/Sources/main.swift
@@ -10,7 +10,8 @@ var gSurface: ghostty_surface_t?
 var gApp: ghostty_app_t?
 var gWindowConfig = TrolleyGuiConfig(
     initial_width: 0, initial_height: 0, resizable: -1,
-    min_width: 0, min_height: 0, max_width: 0, max_height: 0
+    min_width: 0, min_height: 0, max_width: 0, max_height: 0,
+    macos_titlebar_style: 0
 )
 
 // ---------------------------------------------------------------------------
@@ -221,6 +222,7 @@ class TrolleyView: NSView, NSTextInputClient {
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
+        registerForDraggedTypes([.fileURL])
     }
 
     required init?(coder: NSCoder) {
@@ -438,6 +440,50 @@ class TrolleyView: NSView, NSTextInputClient {
         mods |= Int32(momentum) << 1
         ghostty_surface_mouse_scroll(surface, x, y, mods)
     }
+
+    // MARK: - Drag and drop
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        if sender.draggingPasteboard.canReadObject(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) {
+            return .copy
+        }
+        return []
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let surface = gSurface else { return false }
+        guard let urls = sender.draggingPasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] else { return false }
+
+        let paths = urls.map { shellEscape($0.path) }
+        let text = paths.joined(separator: " ")
+
+        // Send each character as a key press to the terminal
+        for char in text {
+            let str = String(char)
+            str.withCString { ptr in
+                var key_ev = ghostty_input_key_s()
+                key_ev.action = GHOSTTY_ACTION_PRESS
+                key_ev.keycode = 0
+                key_ev.mods = ghostty_input_mods_e(GHOSTTY_MODS_NONE.rawValue)
+                key_ev.consumed_mods = ghostty_input_mods_e(GHOSTTY_MODS_NONE.rawValue)
+                key_ev.composing = false
+                key_ev.text = ptr
+                key_ev.unshifted_codepoint = char.unicodeScalars.first?.value ?? 0
+                _ = ghostty_surface_key(surface, key_ev)
+            }
+        }
+        return true
+    }
+
+    private func shellEscape(_ path: String) -> String {
+        if path.rangeOfCharacter(from: .init(charactersIn: " \t'\"\\!$`#&|;(){}[]<>?*~")) != nil {
+            return "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        }
+        return path
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -498,6 +544,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             fputs("trolley: ghostty_app_new failed\n", stderr)
             exit(1)
         }
+        // Read background and foreground colors before freeing config
+        var bgColor: NSColor = .black
+        var fgColor: NSColor = .white
+        var bg = ghostty_config_color_s(r: 0, g: 0, b: 0)
+        if ghostty_config_get(config, &bg, "background", 10) {
+            bgColor = NSColor(
+                red: CGFloat(bg.r) / 255.0,
+                green: CGFloat(bg.g) / 255.0,
+                blue: CGFloat(bg.b) / 255.0,
+                alpha: 1.0
+            )
+        }
+        var fg = ghostty_config_color_s(r: 255, g: 255, b: 255)
+        if ghostty_config_get(config, &fg, "foreground", 10) {
+            fgColor = NSColor(
+                red: CGFloat(fg.r) / 255.0,
+                green: CGFloat(fg.g) / 255.0,
+                blue: CGFloat(fg.b) / 255.0,
+                alpha: 1.0
+            )
+        }
+
         ghostty_config_free(config)
         gApp = app
 
@@ -517,6 +585,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             defer: false
         )
         window.title = "trolley"
+
+        // Apply macOS titlebar style: 0 = visible (default), 1 = hidden, 2 = transparent
+        if gWindowConfig.macos_titlebar_style == 1 || gWindowConfig.macos_titlebar_style == 2 {
+            window.titlebarAppearsTransparent = true
+            window.backgroundColor = bgColor
+            if gWindowConfig.macos_titlebar_style == 1 {
+                window.titleVisibility = .hidden
+            }
+        }
 
         // Min/max size limits (each dimension independent)
         if gWindowConfig.min_width > 0 || gWindowConfig.min_height > 0 {
@@ -560,6 +637,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         ghostty_surface_set_size(surface, UInt32(backed.width), UInt32(backed.height))
         ghostty_surface_set_content_scale(surface, Double(window.backingScaleFactor), Double(window.backingScaleFactor))
         ghostty_surface_set_focus(surface, true)
+
+        // Match window appearance to terminal background brightness
+        if gWindowConfig.macos_titlebar_style == 1 || gWindowConfig.macos_titlebar_style == 2 {
+            let brightness = bg.r > 128 || bg.g > 128 || bg.b > 128
+            window.appearance = NSAppearance(named: brightness ? .aqua : .darkAqua)
+        }
 
         // -- Show window --
         window.makeKeyAndOrderFront(nil)

--- a/runtime/macos/Sources/main.swift
+++ b/runtime/macos/Sources/main.swift
@@ -46,6 +46,14 @@ func actionCallback(
     case GHOSTTY_ACTION_SET_TITLE:
         let title = String(cString: action.action.set_title.title)
         gWindow?.title = title
+        // Update app menu title to match the window title
+        if let appMenu = NSApp.mainMenu?.item(at: 0)?.submenu {
+            appMenu.title = title
+            // Update the About item too
+            if let aboutItem = appMenu.items.first {
+                aboutItem.title = "About \(title)"
+            }
+        }
         return true
 
     case GHOSTTY_ACTION_QUIT:
@@ -490,7 +498,74 @@ class TrolleyView: NSView, NSTextInputClient {
 // AppDelegate
 // ---------------------------------------------------------------------------
 class AppDelegate: NSObject, NSApplicationDelegate {
+
+    // MARK: - Menu bar
+
+    private func buildMenuBar() {
+        let mainMenu = NSMenu()
+
+        // ---- App menu ----
+        let appMenuItem = NSMenuItem()
+        mainMenu.addItem(appMenuItem)
+        let appMenu = NSMenu()
+        appMenuItem.submenu = appMenu
+
+        appMenu.addItem(withTitle: "About Trolley", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(.separator())
+        appMenu.addItem(withTitle: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+
+        // ---- Edit menu ----
+        let editMenuItem = NSMenuItem()
+        mainMenu.addItem(editMenuItem)
+        let editMenu = NSMenu(title: "Edit")
+        editMenuItem.submenu = editMenu
+
+        // Copy/Paste/Select All: use nil target + key equivalents so ghostty keybinds handle them
+        let copyItem = NSMenuItem(title: "Copy", action: nil, keyEquivalent: "c")
+        copyItem.keyEquivalentModifierMask = [.command]
+        editMenu.addItem(copyItem)
+
+        let pasteItem = NSMenuItem(title: "Paste", action: nil, keyEquivalent: "v")
+        pasteItem.keyEquivalentModifierMask = [.command]
+        editMenu.addItem(pasteItem)
+
+        let selectAllItem = NSMenuItem(title: "Select All", action: nil, keyEquivalent: "a")
+        selectAllItem.keyEquivalentModifierMask = [.command]
+        editMenu.addItem(selectAllItem)
+
+        // ---- View menu ----
+        let viewMenuItem = NSMenuItem()
+        mainMenu.addItem(viewMenuItem)
+        let viewMenu = NSMenu(title: "View")
+        viewMenuItem.submenu = viewMenu
+
+        let fontUpItem = NSMenuItem(title: "Increase Font Size", action: nil, keyEquivalent: "=")
+        fontUpItem.keyEquivalentModifierMask = [.command]
+        viewMenu.addItem(fontUpItem)
+
+        let fontDownItem = NSMenuItem(title: "Decrease Font Size", action: nil, keyEquivalent: "-")
+        fontDownItem.keyEquivalentModifierMask = [.command]
+        viewMenu.addItem(fontDownItem)
+
+        // ---- Window menu ----
+        let windowMenuItem = NSMenuItem()
+        mainMenu.addItem(windowMenuItem)
+        let windowMenu = NSMenu(title: "Window")
+        windowMenuItem.submenu = windowMenu
+
+        windowMenu.addItem(withTitle: "Minimize", action: #selector(NSWindow.performMiniaturize(_:)), keyEquivalent: "m")
+        windowMenu.addItem(withTitle: "Zoom", action: #selector(NSWindow.performZoom(_:)), keyEquivalent: "")
+        windowMenu.addItem(.separator())
+        windowMenu.addItem(withTitle: "Bring All to Front", action: #selector(NSApplication.arrangeInFront(_:)), keyEquivalent: "")
+
+        NSApp.mainMenu = mainMenu
+        NSApp.windowsMenu = windowMenu
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // -- Build standard menu bar --
+        buildMenuBar()
+
         // -- Set CWD to exe dir so relative paths (e.g. command = direct:./<slug>_core) resolve --
         FileManager.default.changeCurrentDirectoryPath(getExeDir())
 


### PR DESCRIPTION
## Summary

- Adds a new `macos_titlebar_style` option to the `[gui]` section of `trolley.toml` that controls the macOS window titlebar appearance
- Adds drag-and-drop support for files onto the terminal window

### Titlebar styles

| Value | Behavior |
|-------|----------|
| `"visible"` | Normal titled window (default, no change) |
| `"hidden"` | Transparent titlebar, title text hidden, traffic light buttons remain |
| `"transparent"` | Transparent titlebar background, title text visible |

Both `hidden` and `transparent` styles:
- Read the `background` color from the ghostty config and set it as the window background so the titlebar blends seamlessly with the terminal
- Auto-detect light/dark background and set the window appearance accordingly so title text contrasts properly

### Drag and drop

Files dragged onto the terminal window have their shell-escaped paths typed into the terminal, matching standard terminal emulator behavior.

### Changes

- **`config/src/lib.rs`** — Added `MacosTitlebarStyle` enum and `macos_titlebar_style` field to both `Gui` (TOML config) and `TrolleyGuiConfig` (C ABI struct)
- **`runtime/macos/Sources/main.swift`** — Apply titlebar style to NSWindow, read ghostty background color, register for file drag-and-drop

### Example

```toml
[gui]
macos_titlebar_style = "transparent"
```

## Test plan

- [x] Verified `"transparent"` — titlebar blends with terminal background
- [x] Verified `"hidden"` — title text hidden, traffic lights remain
- [x] Verified default (no setting) — normal titled window, no regression
- [x] Verified drag-and-drop — file paths are shell-escaped and typed into terminal
- [x] Verified dark background detection — title text renders white on dark backgrounds