### PR TITLE
Add windows-only precise timer feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ The manifest file `trolley.toml` has the following sections:
 binaries = { x86_64 = "path/to/binary", aarch64 = "path/to/binary" }
 ```
 
+On Windows, `precise_timer = true` requests 1ms timer resolution instead of
+the default ~15.6ms. This reduces timer jitter and can improve animation
+smoothness, but might slightly increase CPU usage.
+
+```toml
+[windows]
+binaries = { x86_64 = "path/to/app.exe" }
+precise_timer = true
+```
+
 ### `[gui]` -- optional
 
 `initial_width`, `initial_height`, `resizable`, `min_width`, `min_height`,

--- a/README.md
+++ b/README.md
@@ -151,14 +151,14 @@ The manifest file `trolley.toml` has the following sections:
 binaries = { x86_64 = "path/to/binary", aarch64 = "path/to/binary" }
 ```
 
-On Windows, `precise_timer = true` requests 1ms timer resolution instead of
-the default ~15.6ms. This reduces timer jitter and can improve animation
-smoothness, but might slightly increase CPU usage.
+On Windows, 1ms timer resolution is enabled by default instead of the usual
+~15.6ms. This reduces timer jitter and can improve animation smoothness, but
+might slightly increase CPU usage. Set `precise_timer = false` to opt out.
 
 ```toml
 [windows]
 binaries = { x86_64 = "path/to/app.exe" }
-precise_timer = true
+precise_timer = false
 ```
 
 ### `[gui]` -- optional

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -48,6 +48,7 @@ pub fn run(path: Option<String>) -> Result<()> {
     });
     let windows = Some(Windows {
         binaries: all_arches,
+        precise_timer: None,
     });
 
     let manifest = Config {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -441,7 +441,7 @@ pub struct Windows {
     /// Request 1ms timer resolution via timeBeginPeriod.
     /// Reduces timer jitter from ~15.6ms to ~1ms, improving animation
     /// smoothness at the cost of slightly higher power consumption.
-    /// Defaults to false.
+    /// Defaults to true; set to false to opt out.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub precise_timer: Option<bool>,
 }
@@ -866,8 +866,15 @@ pub struct TrolleyGuiConfig {
     pub max_width: u32,
     /// Maximum height in pixels. 0 = unset.
     pub max_height: u32,
-    /// Windows: request 1ms timer resolution. 0 = false (default), 1 = true.
+    /// Windows: request 1ms timer resolution. 0 = false, 1 = true (default).
     pub win_precise_timer: u8,
+}
+
+fn windows_precise_timer_enabled(manifest: &Config) -> bool {
+    manifest
+        .windows
+        .as_ref()
+        .is_none_or(|windows| windows.precise_timer.unwrap_or(true))
 }
 
 /// Load a trolley manifest and extract the window and environment configs.
@@ -903,10 +910,7 @@ pub unsafe extern "C" fn trolley_load_manifest(
         window_config.min_height = manifest.gui.min_height.unwrap_or(0);
         window_config.max_width = manifest.gui.max_width.unwrap_or(0);
         window_config.max_height = manifest.gui.max_height.unwrap_or(0);
-        window_config.win_precise_timer = manifest
-            .windows
-            .as_ref()
-            .map_or(0, |w| u8::from(w.precise_timer.unwrap_or(false)));
+        window_config.win_precise_timer = u8::from(windows_precise_timer_enabled(&manifest));
 
         // Report ghostty config length so the caller can allocate.
         let config_string = ghostty_config_string(&manifest);
@@ -1050,6 +1054,39 @@ binaries = { aarch64 = "my-app-mac" }
         assert_eq!(macos.binaries.len(), 1);
         assert_eq!(macos.binaries[&Arch::Aarch64], "my-app-mac");
         assert!(manifest.windows.is_none());
+    }
+
+    #[test]
+    fn windows_precise_timer_defaults_true_when_omitted() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[windows]
+binaries = { x86_64 = "my-app.exe" }
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        assert!(windows_precise_timer_enabled(&manifest));
+    }
+
+    #[test]
+    fn windows_precise_timer_can_be_disabled() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[windows]
+binaries = { x86_64 = "my-app.exe" }
+precise_timer = false
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        assert!(!windows_precise_timer_enabled(&manifest));
     }
 
     // -----------------------------------------------------------------------

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -438,6 +438,12 @@ pub struct Macos {
 #[serde(deny_unknown_fields)]
 pub struct Windows {
     pub binaries: BTreeMap<Arch, String>,
+    /// Request 1ms timer resolution via timeBeginPeriod.
+    /// Reduces timer jitter from ~15.6ms to ~1ms, improving animation
+    /// smoothness at the cost of slightly higher power consumption.
+    /// Defaults to false.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub precise_timer: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -860,6 +866,8 @@ pub struct TrolleyGuiConfig {
     pub max_width: u32,
     /// Maximum height in pixels. 0 = unset.
     pub max_height: u32,
+    /// Windows: request 1ms timer resolution. 0 = false (default), 1 = true.
+    pub win_precise_timer: u8,
 }
 
 /// Load a trolley manifest and extract the window and environment configs.
@@ -895,6 +903,10 @@ pub unsafe extern "C" fn trolley_load_manifest(
         window_config.min_height = manifest.gui.min_height.unwrap_or(0);
         window_config.max_width = manifest.gui.max_width.unwrap_or(0);
         window_config.max_height = manifest.gui.max_height.unwrap_or(0);
+        window_config.win_precise_timer = manifest
+            .windows
+            .as_ref()
+            .map_or(0, |w| u8::from(w.precise_timer.unwrap_or(false)));
 
         // Report ghostty config length so the caller can allocate.
         let config_string = ghostty_config_string(&manifest);
@@ -1241,10 +1253,7 @@ binaries = { x86_64 = "my-app" }
 theme = "themes/dracula"
 "#;
         let manifest: Config = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            manifest.embeds.theme.as_deref(),
-            Some("themes/dracula")
-        );
+        assert_eq!(manifest.embeds.theme.as_deref(), Some("themes/dracula"));
     }
 
     #[test]
@@ -1285,10 +1294,7 @@ binaries = { x86_64 = "my-app" }
 data = ["assets", "config/defaults.json"]
 "#;
         let manifest: Config = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            manifest.embeds.data,
-            vec!["assets", "config/defaults.json"]
-        );
+        assert_eq!(manifest.embeds.data, vec!["assets", "config/defaults.json"]);
     }
 
     // -----------------------------------------------------------------------
@@ -1606,7 +1612,9 @@ binaries = { x86_64 = "my-app" }
             toml::Value::String("foo.glsl".into()),
         );
         let err = m.validate().unwrap_err().to_string();
-        assert!(err.contains("[embeds] shaders cannot be used together with [ghostty] custom-shader"));
+        assert!(
+            err.contains("[embeds] shaders cannot be used together with [ghostty] custom-shader")
+        );
     }
 
     #[test]

--- a/runtime/build.zig
+++ b/runtime/build.zig
@@ -24,7 +24,7 @@ const Platform = struct {
                 .root_source_file = b.path("src/platform/windows.zig"),
                 .renderer = .opengl,
                 .font_backend = .fontconfig_freetype,
-                .system_libs = &.{ "opengl32", "gdi32", "user32", "mswsock", "userenv", "ws2_32", "ntdll", "dbghelp" },
+                .system_libs = &.{ "opengl32", "gdi32", "user32", "mswsock", "userenv", "ws2_32", "ntdll", "winmm" },
                 .lib_only = false,
             },
             .macos => .{

--- a/runtime/macos/Sources/main.swift
+++ b/runtime/macos/Sources/main.swift
@@ -10,7 +10,8 @@ var gSurface: ghostty_surface_t?
 var gApp: ghostty_app_t?
 var gWindowConfig = TrolleyGuiConfig(
     initial_width: 0, initial_height: 0, resizable: -1,
-    min_width: 0, min_height: 0, max_width: 0, max_height: 0
+    min_width: 0, min_height: 0, max_width: 0, max_height: 0,
+    win_precise_timer: 0
 )
 
 // ---------------------------------------------------------------------------

--- a/runtime/src/platform/linux.zig
+++ b/runtime/src/platform/linux.zig
@@ -28,6 +28,7 @@ var g_window_config: trolley.TrolleyGuiConfig = .{
     .min_height = 0,
     .max_width = 0,
     .max_height = 0,
+    .win_precise_timer = 0,
 };
 
 // ---------------------------------------------------------------------------

--- a/runtime/src/platform/windows.zig
+++ b/runtime/src/platform/windows.zig
@@ -97,6 +97,14 @@ extern "kernel32" fn ExitProcess(
     uExitCode: u32,
 ) callconv(.winapi) noreturn;
 
+extern "winmm" fn timeBeginPeriod(
+    uPeriod: u32,
+) callconv(.winapi) u32;
+
+extern "winmm" fn timeEndPeriod(
+    uPeriod: u32,
+) callconv(.winapi) u32;
+
 extern "opengl32" fn wglGetProcAddress(
     lpszProc: [*:0]const u8,
 ) callconv(.winapi) ?*const fn () callconv(.winapi) void;
@@ -198,6 +206,7 @@ var g_window_config: trolley.TrolleyGuiConfig = .{
     .min_height = 0,
     .max_width = 0,
     .max_height = 0,
+    .win_precise_timer = 0,
 };
 
 // ---------------------------------------------------------------------------
@@ -857,6 +866,11 @@ pub fn main() !void {
         _ = trolley.trolley_load_manifest(manifest_path.ptr, &g_window_config, &ghostty_len);
     }
 
+    const precise_timer = g_window_config.win_precise_timer != 0;
+    if (precise_timer) {
+        _ = timeBeginPeriod(1);
+    }
+
     // -- Load bundled environment variables (must precede ghostty_init) --
     common.loadBundledEnvironment();
 
@@ -1025,6 +1039,9 @@ pub fn main() !void {
         _ = MsgWaitForMultipleObjects(0, null, FALSE, 16, QS_ALLINPUT);
     }
 
+    if (precise_timer) {
+        _ = timeEndPeriod(1);
+    }
     ExitProcess(0);
 }
 

--- a/runtime/src/platform/windows.zig
+++ b/runtime/src/platform/windows.zig
@@ -206,7 +206,7 @@ var g_window_config: trolley.TrolleyGuiConfig = .{
     .min_height = 0,
     .max_width = 0,
     .max_height = 0,
-    .win_precise_timer = 0,
+    .win_precise_timer = 1,
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds support for optionally requesting high-resolution timer support on Windows. A default timer can have a precision of ~15ms, while requesting high res timer support brings that down to 1ms.

```
[windows]
binaries = { x86_64 = "path/to/app.exe" }
precise_timer = true
```

The TUI app I'm developing requires high refresh rates and combined with #27 , brings render performance inline with Windows Terminal.

I would speculate that any remotely modern system won't have any noticeable performance loss from always requesting a high-res timer, but I erred on the side of making it opt-in. Happy to change it if you prefer to keep the config surface area smaller.