### PR TITLE
Added --apply-ghostty-windows-render-patch option to workaround a ghostty FPS bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,25 @@ Use `--skip-failed-formats` to continue building remaining formats if one fails
 trolley package --skip-failed-formats
 ```
 
+## Windows Render Workaround
+
+Ghostty currently has a Windows renderer wakeup bug that can cause Trolley's
+Windows runtime to update at effectively 2 FPS. Discussion:
+
+`https://github.com/ghostty-org/ghostty/discussions/11877`
+
+If you are building the Windows runtime from source and need this temporary
+workaround, pass:
+
+`just build-runtime --target x86_64-windows --apply-ghostty-windows-render-patch`
+
+or:
+
+`just build --target x86_64-windows --apply-ghostty-windows-render-patch`
+
+This temporarily applies `patches/ghostty/windows-render.patch` to the Ghostty
+submodule for the duration of the build, then reverses it on exit.
+
 ## BUNDLING != SANDBOXING
 
 Trolley simply runs your executable inside a terminal, and in that sense, provides no

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ _runtime-target target:
 
 # Build the trolley CLI
 
-# Flags: [--release] [--target <triple>]
+# Flags: [--release] [--target <triple>] [--apply-ghostty-windows-render-patch]
 build-cli *flags:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -56,6 +56,7 @@ build-cli *flags:
         case "$flag" in
             --target)  next_is_target=1 ;;
             --release) release=1 ;;
+            --apply-ghostty-windows-render-patch) ;;
             *)         echo "Unknown flag: $flag" >&2; exit 1 ;;
         esac
     done
@@ -70,7 +71,7 @@ build-cli *flags:
 
 # Build the config staticlib (manifest parsing, linked into the runtime)
 
-# Flags: [--release] [--target <triple>]
+# Flags: [--release] [--target <triple>] [--apply-ghostty-windows-render-patch]
 build-config *flags:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -87,6 +88,7 @@ build-config *flags:
         case "$flag" in
             --target)  next_is_target=1 ;;
             --release) release=1 ;;
+            --apply-ghostty-windows-render-patch) ;;
             *)         echo "Unknown flag: $flag" >&2; exit 1 ;;
         esac
     done
@@ -100,12 +102,13 @@ build-config *flags:
     cargo build -p trolley-config --quiet $cargo_args
 
 # Build the trolley runtime
-# Flags: [--release] [--target <triple>] [--system <path>]
+# Flags: [--release] [--target <triple>] [--system <path>] [--apply-ghostty-windows-render-patch]
 # No target flag = host default
 # Examples:
 #   just build-runtime --target x86_64-linux
 #   just build-runtime --target aarch64-macos --release
 #   just build-runtime --release --system /nix/store/...-zig-packages
+#   just build-runtime --target x86_64-windows --apply-ghostty-windows-render-patch
 build-runtime *flags:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -116,6 +119,7 @@ build-runtime *flags:
     cargo_profile="debug"
     release=""
     system=""
+    apply_ghostty_windows_render_patch=""
     next_is_target=""
     next_is_system=""
     for flag in {{ flags }}; do
@@ -133,6 +137,7 @@ build-runtime *flags:
             --target)  next_is_target=1 ;;
             --system)  next_is_system=1 ;;
             --release) release=1; optimize="-Doptimize=ReleaseSafe"; prefix="zig-out-release"; cargo_profile="release" ;;
+            --apply-ghostty-windows-render-patch) apply_ghostty_windows_render_patch=1 ;;
             *)         echo "Unknown flag: $flag" >&2; exit 1 ;;
         esac
     done
@@ -171,6 +176,37 @@ build-runtime *flags:
         echo "Error: config lib not found in $config_dir" >&2
         echo "Expected libtrolley_config.a or trolley_config.lib" >&2
         exit 1
+    fi
+
+    cleanup_ghostty_patch() {
+        if [ -n "${ghostty_patch_applied:-}" ]; then
+            if git -C "{{ justfile_directory() }}/ghostty" apply -R "{{ justfile_directory() }}/patches/ghostty/windows-render.patch"; then
+                echo "Removed temporary Ghostty Windows render patch"
+            else
+                echo "Warning: failed to reverse temporary Ghostty Windows render patch" >&2
+            fi
+        fi
+    }
+    trap cleanup_ghostty_patch EXIT INT TERM
+
+    is_windows_target=false
+    if [[ "$target" == *"-windows" ]]; then
+        is_windows_target=true
+    elif [ -z "$target" ] && [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* || "$(uname -o 2>/dev/null)" == "Msys" || -n "${WINDIR:-}" ]]; then
+        is_windows_target=true
+    fi
+
+    if [ -n "$apply_ghostty_windows_render_patch" ]; then
+        if ! $is_windows_target; then
+            echo "Ignoring --apply-ghostty-windows-render-patch for non-Windows build" >&2
+        elif [ -n "$(git -C "{{ justfile_directory() }}/ghostty" status --porcelain)" ]; then
+            echo "Ghostty submodule is dirty; skipping optional Windows render patch" >&2
+        else
+            git -C "{{ justfile_directory() }}/ghostty" apply --check "{{ justfile_directory() }}/patches/ghostty/windows-render.patch"
+            git -C "{{ justfile_directory() }}/ghostty" apply "{{ justfile_directory() }}/patches/ghostty/windows-render.patch"
+            ghostty_patch_applied=1
+            echo "Applied temporary Ghostty Windows render patch"
+        fi
     fi
 
     # Step 1: zig build (libghostty + exe on Linux/Windows, libghostty only on macOS)
@@ -218,6 +254,7 @@ build *flags: (build-cli flags) (build-runtime flags)
 
 # Build and package the CLI for release
 # Requires: --target <triple>
+# Optional: --apply-ghostty-windows-render-patch
 # Ignores: --system (accepted for compatibility with release command)
 release-cli *flags:
     #!/usr/bin/env bash
@@ -238,6 +275,7 @@ release-cli *flags:
         case "$flag" in
             --target)  next_is_target=1 ;;
             --system)  skip_next=1 ;;
+            --apply-ghostty-windows-render-patch) ;;
             *)         echo "Unknown flag: $flag" >&2; exit 1 ;;
         esac
     done
@@ -257,11 +295,13 @@ release-cli *flags:
 # Build and package the runtime for release
 # Requires: --target <triple>
 # Optional: --system <path> (pre-built zig deps from nix build .#deps)
+# Optional: --apply-ghostty-windows-render-patch
 release-runtime *flags:
     #!/usr/bin/env bash
     set -euo pipefail
     target=""
     system=""
+    apply_ghostty_windows_render_patch=""
     next_is_target=""
     next_is_system=""
     for flag in {{ flags }}; do
@@ -278,6 +318,7 @@ release-runtime *flags:
         case "$flag" in
             --target)  next_is_target=1 ;;
             --system)  next_is_system=1 ;;
+            --apply-ghostty-windows-render-patch) apply_ghostty_windows_render_patch=1 ;;
             *)         echo "Unknown flag: $flag" >&2; exit 1 ;;
         esac
     done
@@ -287,6 +328,9 @@ release-runtime *flags:
 
     build_flags="--release --target $target"
     if [ -n "$system" ]; then build_flags="$build_flags --system $system"; fi
+    if [ -n "$apply_ghostty_windows_render_patch" ]; then
+        build_flags="$build_flags --apply-ghostty-windows-render-patch"
+    fi
     just build-runtime $build_flags
 
     exe="trolley"; if [[ "$target" == *-windows ]]; then exe="trolley.exe"; fi

--- a/patches/ghostty/windows-render.patch
+++ b/patches/ghostty/windows-render.patch
@@ -1,0 +1,52 @@
+diff --git a/src/Surface.zig b/src/Surface.zig
+index ebc2a2f43..66a9fdf79 100644
+--- a/src/Surface.zig
++++ b/src/Surface.zig
+@@ -658,7 +658,7 @@ pub fn init(
+             .backend = .{ .exec = io_exec },
+             .mailbox = io_mailbox,
+             .renderer_state = &self.renderer_state,
+-            .renderer_wakeup = render_thread.wakeup,
++            .renderer_wakeup = &self.renderer_thread.wakeup,
+             .renderer_mailbox = render_thread.mailbox,
+             .surface_mailbox = .{ .surface = self, .app = app_mailbox },
+         });
+diff --git a/src/termio/Options.zig b/src/termio/Options.zig
+index a6bf8c4d4..c9da54de2 100644
+--- a/src/termio/Options.zig
++++ b/src/termio/Options.zig
+@@ -32,7 +32,7 @@ renderer_state: *renderer.State,
+ 
+ /// A handle to wake up the renderer. This hints to the renderer that
+ /// a repaint should happen.
+-renderer_wakeup: xev.Async,
++renderer_wakeup: *xev.Async,
+ 
+ /// The mailbox for renderer messages.
+ renderer_mailbox: *renderer.Thread.Mailbox,
+diff --git a/src/termio/Termio.zig b/src/termio/Termio.zig
+index 73e1c46d5..6a6518deb 100644
+--- a/src/termio/Termio.zig
++++ b/src/termio/Termio.zig
+@@ -44,7 +44,7 @@ renderer_state: *renderer.State,
+ 
+ /// A handle to wake up the renderer. This hints to the renderer that
+ /// a repaint should happen.
+-renderer_wakeup: xev.Async,
++renderer_wakeup: *xev.Async,
+ 
+ /// The mailbox for notifying the renderer of things.
+ renderer_mailbox: *renderer.Thread.Mailbox,
+diff --git a/src/termio/stream_handler.zig b/src/termio/stream_handler.zig
+index 5041d916a..0a953e3b1 100644
+--- a/src/termio/stream_handler.zig
++++ b/src/termio/stream_handler.zig
+@@ -38,7 +38,7 @@ pub const StreamHandler = struct {
+ 
+     /// A handle to wake up the renderer. This hints to the renderer that
+     /// a repaint should happen.
+-    renderer_wakeup: xev.Async,
++    renderer_wakeup: *xev.Async,
+ 
+     /// The default cursor state. This is used with CSI q. This is
+     /// set to true when we're currently in the default cursor state.


### PR DESCRIPTION
I spent a fair bit of time trying to track down why my Windows TUI app refresh rate was miserably slow (like 2FPS). After sticking a lot of tracing logs into ghostty itself, I tracked down what seems like a bug in their render thread timer signalling on Windows. Basically what was happening is that the only trigger to cause a render refresh was the 600ms cursor blink timer, any incoming data from the TUI/ConPty wasn't causing a refresh to happen.

I created a discussion topic at the Ghostty repo: https://github.com/ghostty-org/ghostty/discussions/11877

Unfortunately I could not find a way to workaround this issue from the Trolley runtime side of things. This PR adds an optional justfile build argument `--apply-ghostty-windows-render-patch` that manually applies the patch that fixes the Ghostty issue, and then after building, cleans it up. I recognize this is really fragile and could break when you update the submodule for other reasons, thus the opt-in approach. Were that to happen I'd be happy to keep fixing it (file an issue and tag me?).

Once Ghostty acknowledges and fixes the issue, this PR could be reverted when the pinned submodule gets updated.

