### PR TITLE
Windows support for embedding icons into the runtime exe file

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ To support all platforms, provide multiple icons:
 icons = ["assets/icon.png", "assets/icon.ico", "assets/icon.icns"]
 ```
 
+On Windows, the first resolved `.ico` is bundled into the runtime for the app
+window icon, and when packaging on Windows it is also embedded into the bundled
+`*_runtime.exe`.
+
 Glob patterns are also supported (e.g. `"assets/icon.*"`).
 
 ## Package formats

--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ To support all platforms, provide multiple icons:
 icons = ["assets/icon.png", "assets/icon.ico", "assets/icon.icns"]
 ```
 
+On Windows, the first resolved `.ico` is bundled into the runtime for the app
+window icon, and when packaging on Windows it is also embedded into the bundled
+`*_runtime.exe`.
+
 Glob patterns are also supported (e.g. `"assets/icon.*"`).
 
 ## Package formats

--- a/cli/src/commands/common.rs
+++ b/cli/src/commands/common.rs
@@ -10,6 +10,7 @@ pub const CONFIG_FILENAME: &str = "trolley.toml";
 pub const GHOSTTY_CONFIG_FILENAME: &str = "ghostty.conf";
 pub const ENVIRONMENT_FILENAME: &str = "environment";
 pub const FONTS_CONFIG_FILENAME: &str = "fonts.conf";
+pub const WINDOWS_ICON_FILENAME: &str = "app.ico";
 
 // ---------------------------------------------------------------------------
 // ProjectContext — resolved config, paths, ready for commands
@@ -335,6 +336,56 @@ pub fn copy_fonts_to_bundle(font_files: &[PathBuf], output_dir: &Path) -> Result
     std::fs::write(&fonts_conf, FONTCONFIG_TEMPLATE)
         .with_context(|| format!("writing {}", fonts_conf.display()))?;
 
+    Ok(())
+}
+
+/// Resolve the first Windows `.ico` declared by `[app].icons`.
+///
+/// The chosen icon is bundled under a fixed filename so the Windows runtime can
+/// load it without depending on source-tree-relative manifest paths.
+pub fn resolve_windows_icon(project_dir: &Path, config: &Config) -> Result<Option<PathBuf>> {
+    for pattern in &config.app.icons {
+        let pattern_path = project_dir.join(pattern);
+        let pattern = pattern_path.to_string_lossy().into_owned();
+        let mut matches = Vec::new();
+
+        for entry in
+            glob::glob(&pattern).with_context(|| format!("invalid icon glob: {pattern}"))?
+        {
+            let path = entry.with_context(|| format!("reading icon glob: {pattern}"))?;
+            let is_ico = path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext.eq_ignore_ascii_case("ico"))
+                .unwrap_or(false);
+            if !is_ico {
+                continue;
+            }
+
+            matches.push(
+                path.canonicalize()
+                    .with_context(|| format!("resolving icon {}", path.display()))?,
+            );
+        }
+
+        matches.sort();
+        if let Some(path) = matches.into_iter().next() {
+            return Ok(Some(path));
+        }
+    }
+
+    Ok(None)
+}
+
+pub fn copy_windows_icon_to_bundle(icon_path: &Path, output_dir: &Path) -> Result<()> {
+    let dest = output_dir.join(WINDOWS_ICON_FILENAME);
+    std::fs::copy(icon_path, &dest).with_context(|| {
+        format!(
+            "copying Windows icon {} to {}",
+            icon_path.display(),
+            dest.display()
+        )
+    })?;
     Ok(())
 }
 
@@ -839,6 +890,44 @@ mod tests {
         manifest.environment.env_file = Some("nonexistent.env".into());
         let result = assemble_environment(dir.path(), &manifest);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_windows_icon_prefers_ico_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let assets_dir = dir.path().join("assets");
+        std::fs::create_dir_all(&assets_dir).unwrap();
+        std::fs::write(assets_dir.join("icon.png"), b"png").unwrap();
+        std::fs::write(assets_dir.join("icon.ico"), b"ico").unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.app.icons = vec!["assets/icon.*".into()];
+
+        let resolved = resolve_windows_icon(dir.path(), &manifest).unwrap();
+        assert_eq!(
+            resolved,
+            Some(assets_dir.join("icon.ico").canonicalize().unwrap())
+        );
+    }
+
+    #[test]
+    fn resolve_windows_icon_uses_first_pattern_with_ico() {
+        let dir = tempfile::tempdir().unwrap();
+        let assets_dir = dir.path().join("assets");
+        let icons_dir = dir.path().join("icons");
+        std::fs::create_dir_all(&assets_dir).unwrap();
+        std::fs::create_dir_all(&icons_dir).unwrap();
+        std::fs::write(assets_dir.join("icon.png"), b"png").unwrap();
+        std::fs::write(icons_dir.join("app.ico"), b"ico").unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.app.icons = vec!["assets/*".into(), "icons/*".into()];
+
+        let resolved = resolve_windows_icon(dir.path(), &manifest).unwrap();
+        assert_eq!(
+            resolved,
+            Some(icons_dir.join("app.ico").canonicalize().unwrap())
+        );
     }
 
     #[test]

--- a/cli/src/commands/common.rs
+++ b/cli/src/commands/common.rs
@@ -10,6 +10,7 @@ pub const CONFIG_FILENAME: &str = "trolley.toml";
 pub const GHOSTTY_CONFIG_FILENAME: &str = "ghostty.conf";
 pub const ENVIRONMENT_FILENAME: &str = "environment";
 pub const FONTS_CONFIG_FILENAME: &str = "fonts.conf";
+pub const WINDOWS_ICON_FILENAME: &str = "app.ico";
 
 // ---------------------------------------------------------------------------
 // ProjectContext — resolved config, paths, ready for commands
@@ -335,6 +336,56 @@ pub fn copy_fonts_to_bundle(font_files: &[PathBuf], output_dir: &Path) -> Result
     std::fs::write(&fonts_conf, FONTCONFIG_TEMPLATE)
         .with_context(|| format!("writing {}", fonts_conf.display()))?;
 
+    Ok(())
+}
+
+/// Resolve the first Windows `.ico` declared by `[app].icons`.
+///
+/// The chosen icon is bundled under a fixed filename so the Windows runtime can
+/// load it without depending on source-tree-relative manifest paths.
+pub fn resolve_windows_icon(project_dir: &Path, config: &Config) -> Result<Option<PathBuf>> {
+    for pattern in &config.app.icons {
+        let pattern_path = project_dir.join(pattern);
+        let pattern = pattern_path.to_string_lossy().into_owned();
+        let mut matches = Vec::new();
+
+        for entry in
+            glob::glob(&pattern).with_context(|| format!("invalid icon glob: {pattern}"))?
+        {
+            let path = entry.with_context(|| format!("reading icon glob: {pattern}"))?;
+            let is_ico = path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext.eq_ignore_ascii_case("ico"))
+                .unwrap_or(false);
+            if !is_ico {
+                continue;
+            }
+
+            matches.push(
+                path.canonicalize()
+                    .with_context(|| format!("resolving icon {}", path.display()))?,
+            );
+        }
+
+        matches.sort();
+        if let Some(path) = matches.into_iter().next() {
+            return Ok(Some(path));
+        }
+    }
+
+    Ok(None)
+}
+
+pub fn copy_windows_icon_to_bundle(icon_path: &Path, output_dir: &Path) -> Result<()> {
+    let dest = output_dir.join(WINDOWS_ICON_FILENAME);
+    std::fs::copy(icon_path, &dest).with_context(|| {
+        format!(
+            "copying Windows icon {} to {}",
+            icon_path.display(),
+            dest.display()
+        )
+    })?;
     Ok(())
 }
 
@@ -829,6 +880,44 @@ mod tests {
         manifest.environment.env_file = Some("nonexistent.env".into());
         let result = assemble_environment(dir.path(), &manifest);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_windows_icon_prefers_ico_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let assets_dir = dir.path().join("assets");
+        std::fs::create_dir_all(&assets_dir).unwrap();
+        std::fs::write(assets_dir.join("icon.png"), b"png").unwrap();
+        std::fs::write(assets_dir.join("icon.ico"), b"ico").unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.app.icons = vec!["assets/icon.*".into()];
+
+        let resolved = resolve_windows_icon(dir.path(), &manifest).unwrap();
+        assert_eq!(
+            resolved,
+            Some(assets_dir.join("icon.ico").canonicalize().unwrap())
+        );
+    }
+
+    #[test]
+    fn resolve_windows_icon_uses_first_pattern_with_ico() {
+        let dir = tempfile::tempdir().unwrap();
+        let assets_dir = dir.path().join("assets");
+        let icons_dir = dir.path().join("icons");
+        std::fs::create_dir_all(&assets_dir).unwrap();
+        std::fs::create_dir_all(&icons_dir).unwrap();
+        std::fs::write(assets_dir.join("icon.png"), b"png").unwrap();
+        std::fs::write(icons_dir.join("app.ico"), b"ico").unwrap();
+
+        let mut manifest = test_manifest();
+        manifest.app.icons = vec!["assets/*".into(), "icons/*".into()];
+
+        let resolved = resolve_windows_icon(dir.path(), &manifest).unwrap();
+        assert_eq!(
+            resolved,
+            Some(icons_dir.join("app.ico").canonicalize().unwrap())
+        );
     }
 
     #[test]

--- a/cli/src/commands/common.rs
+++ b/cli/src/commands/common.rs
@@ -10,7 +10,10 @@ pub const CONFIG_FILENAME: &str = "trolley.toml";
 pub const GHOSTTY_CONFIG_FILENAME: &str = "ghostty.conf";
 pub const ENVIRONMENT_FILENAME: &str = "environment";
 pub const FONTS_CONFIG_FILENAME: &str = "fonts.conf";
-pub const WINDOWS_ICON_FILENAME: &str = "app.ico";
+
+/// Bundled Windows icon filename as a `&str`; shares its source with the Zig
+/// runtime — see `trolley_config::windows_icon_filename_str`.
+pub use trolley_config::windows_icon_filename_str;
 
 // ---------------------------------------------------------------------------
 // ProjectContext — resolved config, paths, ready for commands
@@ -378,7 +381,7 @@ pub fn resolve_windows_icon(project_dir: &Path, config: &Config) -> Result<Optio
 }
 
 pub fn copy_windows_icon_to_bundle(icon_path: &Path, output_dir: &Path) -> Result<()> {
-    let dest = output_dir.join(WINDOWS_ICON_FILENAME);
+    let dest = output_dir.join(windows_icon_filename_str());
     std::fs::copy(icon_path, &dest).with_context(|| {
         format!(
             "copying Windows icon {} to {}",

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub mod formats;
 pub mod init;
 pub mod package;
 pub mod run;
+pub mod windows_exe_icon;

--- a/cli/src/commands/package.rs
+++ b/cli/src/commands/package.rs
@@ -99,7 +99,7 @@ pub fn run(
             .resources
             .extend(common::copy_data_path_to_bundle(data_path, &bundle_dir)?);
     }
-    if let Some(icon_path) = &windows_icon {
+    if target.is_windows() && let Some(icon_path) = &windows_icon {
         common::copy_windows_icon_to_bundle(icon_path, &bundle_dir)?;
         manifest
             .resources
@@ -120,7 +120,7 @@ pub fn run(
         .with_context(|| format!("copying runtime to {}", bundle_dir.display()))?;
     fs::copy(&tui_binary, bundle_dir.join(&manifest.core_name))
         .with_context(|| format!("copying TUI binary to {}", bundle_dir.display()))?;
-    let stamped_runtime_icon = if let Some(icon_path) = &windows_icon {
+    let stamped_runtime_icon = if target.is_windows() && let Some(icon_path) = &windows_icon {
         super::windows_exe_icon::stamp_exe_icon(&bundled_runtime, icon_path).with_context(|| {
             format!(
                 "stamping Windows app icon into {}",
@@ -193,11 +193,11 @@ pub fn run(
     for data_path in &data_paths {
         println!("  {}  (embedded data)", data_path.relative_path.display());
     }
-    if windows_icon.is_some() {
+    if target.is_windows() && windows_icon.is_some() {
         println!("  {}  (Windows app icon)", common::WINDOWS_ICON_FILENAME);
         if stamped_runtime_icon {
             println!("  {}  (Windows exe icon stamped)", manifest.runtime_name);
-        } else if target.is_windows() {
+        } else {
             eprintln!(
                 "Warning: Windows exe icon stamping is only available when packaging on Windows."
             );

--- a/cli/src/commands/package.rs
+++ b/cli/src/commands/package.rs
@@ -84,6 +84,11 @@ pub fn run(
     let font_family_names = common::read_font_family_names(&font_files)?;
     let shaders = common::resolve_shaders(&ctx.project_dir, &ctx.config)?;
     let data_paths = common::resolve_data_paths(&ctx.project_dir, &ctx.config)?;
+    let windows_icon = if target.is_windows() {
+        common::resolve_windows_icon(&ctx.project_dir, &ctx.config)?
+    } else {
+        None
+    };
 
     for shader in &shaders {
         common::copy_shader_to_bundle(shader, &bundle_dir)?;
@@ -93,6 +98,12 @@ pub fn run(
         manifest
             .resources
             .extend(common::copy_data_path_to_bundle(data_path, &bundle_dir)?);
+    }
+    if let Some(icon_path) = &windows_icon {
+        common::copy_windows_icon_to_bundle(icon_path, &bundle_dir)?;
+        manifest
+            .resources
+            .push(PathBuf::from(common::WINDOWS_ICON_FILENAME));
     }
 
     // Assemble ghostty.conf — command references the renamed TUI binary
@@ -104,10 +115,21 @@ pub fn run(
     )?;
 
     // Copy runtime and TUI binary into bundle with renamed filenames
-    fs::copy(&runtime, bundle_dir.join(&manifest.runtime_name))
+    let bundled_runtime = bundle_dir.join(&manifest.runtime_name);
+    fs::copy(&runtime, &bundled_runtime)
         .with_context(|| format!("copying runtime to {}", bundle_dir.display()))?;
     fs::copy(&tui_binary, bundle_dir.join(&manifest.core_name))
         .with_context(|| format!("copying TUI binary to {}", bundle_dir.display()))?;
+    let stamped_runtime_icon = if let Some(icon_path) = &windows_icon {
+        super::windows_exe_icon::stamp_exe_icon(&bundled_runtime, icon_path).with_context(|| {
+            format!(
+                "stamping Windows app icon into {}",
+                bundled_runtime.display()
+            )
+        })?
+    } else {
+        false
+    };
     fs::write(
         bundle_dir.join(common::GHOSTTY_CONFIG_FILENAME),
         &config_bytes,
@@ -170,6 +192,16 @@ pub fn run(
     }
     for data_path in &data_paths {
         println!("  {}  (embedded data)", data_path.relative_path.display());
+    }
+    if windows_icon.is_some() {
+        println!("  {}  (Windows app icon)", common::WINDOWS_ICON_FILENAME);
+        if stamped_runtime_icon {
+            println!("  {}  (Windows exe icon stamped)", manifest.runtime_name);
+        } else if target.is_windows() {
+            eprintln!(
+                "Warning: Windows exe icon stamping is only available when packaging on Windows."
+            );
+        }
     }
 
     // Build packages unless bundle-only

--- a/cli/src/commands/package.rs
+++ b/cli/src/commands/package.rs
@@ -84,6 +84,11 @@ pub fn run(
     let font_family_names = common::read_font_family_names(&font_files)?;
     let shaders = common::resolve_shaders(&ctx.project_dir, &ctx.config)?;
     let data_paths = common::resolve_data_paths(&ctx.project_dir, &ctx.config)?;
+    let windows_icon = if target.is_windows() {
+        common::resolve_windows_icon(&ctx.project_dir, &ctx.config)?
+    } else {
+        None
+    };
 
     for shader in &shaders {
         common::copy_shader_to_bundle(shader, &bundle_dir)?;
@@ -93,6 +98,12 @@ pub fn run(
         manifest
             .resources
             .extend(common::copy_data_path_to_bundle(data_path, &bundle_dir)?);
+    }
+    if let Some(icon_path) = &windows_icon {
+        common::copy_windows_icon_to_bundle(icon_path, &bundle_dir)?;
+        manifest
+            .resources
+            .push(PathBuf::from(common::WINDOWS_ICON_FILENAME));
     }
 
     // Assemble ghostty.conf — command references the renamed TUI binary
@@ -105,10 +116,21 @@ pub fn run(
     )?;
 
     // Copy runtime and TUI binary into bundle with renamed filenames
-    fs::copy(&runtime, bundle_dir.join(&manifest.runtime_name))
+    let bundled_runtime = bundle_dir.join(&manifest.runtime_name);
+    fs::copy(&runtime, &bundled_runtime)
         .with_context(|| format!("copying runtime to {}", bundle_dir.display()))?;
     fs::copy(&tui_binary, bundle_dir.join(&manifest.core_name))
         .with_context(|| format!("copying TUI binary to {}", bundle_dir.display()))?;
+    let stamped_runtime_icon = if let Some(icon_path) = &windows_icon {
+        super::windows_exe_icon::stamp_exe_icon(&bundled_runtime, icon_path).with_context(|| {
+            format!(
+                "stamping Windows app icon into {}",
+                bundled_runtime.display()
+            )
+        })?
+    } else {
+        false
+    };
     fs::write(
         bundle_dir.join(common::GHOSTTY_CONFIG_FILENAME),
         &config_bytes,
@@ -171,6 +193,16 @@ pub fn run(
     }
     for data_path in &data_paths {
         println!("  {}  (embedded data)", data_path.relative_path.display());
+    }
+    if windows_icon.is_some() {
+        println!("  {}  (Windows app icon)", common::WINDOWS_ICON_FILENAME);
+        if stamped_runtime_icon {
+            println!("  {}  (Windows exe icon stamped)", manifest.runtime_name);
+        } else if target.is_windows() {
+            eprintln!(
+                "Warning: Windows exe icon stamping is only available when packaging on Windows."
+            );
+        }
     }
 
     // Build packages unless bundle-only

--- a/cli/src/commands/package.rs
+++ b/cli/src/commands/package.rs
@@ -103,7 +103,7 @@ pub fn run(
         common::copy_windows_icon_to_bundle(icon_path, &bundle_dir)?;
         manifest
             .resources
-            .push(PathBuf::from(common::WINDOWS_ICON_FILENAME));
+            .push(PathBuf::from(common::windows_icon_filename_str()));
     }
 
     // Assemble ghostty.conf — command references the renamed TUI binary
@@ -195,7 +195,7 @@ pub fn run(
         println!("  {}  (embedded data)", data_path.relative_path.display());
     }
     if target.is_windows() && windows_icon.is_some() {
-        println!("  {}  (Windows app icon)", common::WINDOWS_ICON_FILENAME);
+        println!("  {}  (Windows app icon)", common::windows_icon_filename_str());
         if stamped_runtime_icon {
             println!("  {}  (Windows exe icon stamped)", manifest.runtime_name);
         } else {

--- a/cli/src/commands/package.rs
+++ b/cli/src/commands/package.rs
@@ -99,7 +99,7 @@ pub fn run(
             .resources
             .extend(common::copy_data_path_to_bundle(data_path, &bundle_dir)?);
     }
-    if let Some(icon_path) = &windows_icon {
+    if target.is_windows() && let Some(icon_path) = &windows_icon {
         common::copy_windows_icon_to_bundle(icon_path, &bundle_dir)?;
         manifest
             .resources
@@ -121,7 +121,7 @@ pub fn run(
         .with_context(|| format!("copying runtime to {}", bundle_dir.display()))?;
     fs::copy(&tui_binary, bundle_dir.join(&manifest.core_name))
         .with_context(|| format!("copying TUI binary to {}", bundle_dir.display()))?;
-    let stamped_runtime_icon = if let Some(icon_path) = &windows_icon {
+    let stamped_runtime_icon = if target.is_windows() && let Some(icon_path) = &windows_icon {
         super::windows_exe_icon::stamp_exe_icon(&bundled_runtime, icon_path).with_context(|| {
             format!(
                 "stamping Windows app icon into {}",
@@ -194,11 +194,11 @@ pub fn run(
     for data_path in &data_paths {
         println!("  {}  (embedded data)", data_path.relative_path.display());
     }
-    if windows_icon.is_some() {
+    if target.is_windows() && windows_icon.is_some() {
         println!("  {}  (Windows app icon)", common::WINDOWS_ICON_FILENAME);
         if stamped_runtime_icon {
             println!("  {}  (Windows exe icon stamped)", manifest.runtime_name);
-        } else if target.is_windows() {
+        } else {
             eprintln!(
                 "Warning: Windows exe icon stamping is only available when packaging on Windows."
             );

--- a/cli/src/commands/windows_exe_icon.rs
+++ b/cli/src/commands/windows_exe_icon.rs
@@ -1,0 +1,299 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+
+#[cfg(windows)]
+const RT_ICON: u16 = 3;
+#[cfg(windows)]
+const RT_GROUP_ICON: u16 = 14;
+#[cfg(windows)]
+const MAIN_ICON_ID: u16 = 1;
+const FIRST_IMAGE_ID: u16 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IconImage {
+    width: u8,
+    height: u8,
+    color_count: u8,
+    reserved: u8,
+    planes: u16,
+    bit_count: u16,
+    bytes: Vec<u8>,
+}
+
+pub fn stamp_exe_icon(exe_path: &Path, icon_path: &Path) -> Result<bool> {
+    let images = parse_ico(icon_path)?;
+    if images.is_empty() {
+        bail!("ICO file contains no images: {}", icon_path.display());
+    }
+
+    #[cfg(windows)]
+    {
+        stamp_exe_icon_windows(exe_path, &images)
+            .with_context(|| format!("updating Windows resources in {}", exe_path.display()))?;
+        Ok(true)
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = exe_path;
+        let _ = images;
+        Ok(false)
+    }
+}
+
+fn parse_ico(icon_path: &Path) -> Result<Vec<IconImage>> {
+    let data =
+        fs::read(icon_path).with_context(|| format!("reading icon {}", icon_path.display()))?;
+    if data.len() < 6 {
+        bail!("ICO file is too small: {}", icon_path.display());
+    }
+
+    let reserved = read_u16(&data, 0)?;
+    let file_type = read_u16(&data, 2)?;
+    let count = read_u16(&data, 4)? as usize;
+    if reserved != 0 || file_type != 1 {
+        bail!("invalid ICO header in {}", icon_path.display());
+    }
+    if count == 0 {
+        bail!("ICO file contains no images: {}", icon_path.display());
+    }
+
+    let entries_end = 6usize
+        .checked_add(count.checked_mul(16).context("ICO entry count overflow")?)
+        .context("ICO entry table overflow")?;
+    if data.len() < entries_end {
+        bail!("ICO entry table is truncated: {}", icon_path.display());
+    }
+
+    let mut images = Vec::with_capacity(count);
+    for i in 0..count {
+        let base = 6 + (i * 16);
+        let image_size = read_u32(&data, base + 8)? as usize;
+        let image_offset = read_u32(&data, base + 12)? as usize;
+        let image_end = image_offset
+            .checked_add(image_size)
+            .context("ICO image data overflow")?;
+        if image_end > data.len() {
+            bail!("ICO image data is truncated: {}", icon_path.display());
+        }
+
+        images.push(IconImage {
+            width: data[base],
+            height: data[base + 1],
+            color_count: data[base + 2],
+            reserved: data[base + 3],
+            planes: read_u16(&data, base + 4)?,
+            bit_count: read_u16(&data, base + 6)?,
+            bytes: data[image_offset..image_end].to_vec(),
+        });
+    }
+
+    Ok(images)
+}
+
+fn build_group_icon_resource(images: &[IconImage]) -> Result<Vec<u8>> {
+    let count = u16::try_from(images.len()).context("too many ICO images")?;
+    let capacity = 6usize
+        .checked_add(
+            images
+                .len()
+                .checked_mul(14)
+                .context("group icon entry overflow")?,
+        )
+        .context("group icon size overflow")?;
+    let mut resource = Vec::with_capacity(capacity);
+    resource.extend_from_slice(&0u16.to_le_bytes());
+    resource.extend_from_slice(&1u16.to_le_bytes());
+    resource.extend_from_slice(&count.to_le_bytes());
+
+    for (index, image) in images.iter().enumerate() {
+        let image_id = u16::try_from(index)
+            .ok()
+            .and_then(|v| v.checked_add(FIRST_IMAGE_ID))
+            .context("too many ICO images for resource ids")?;
+        let byte_len = u32::try_from(image.bytes.len()).context("icon image is too large")?;
+
+        resource.push(image.width);
+        resource.push(image.height);
+        resource.push(image.color_count);
+        resource.push(image.reserved);
+        resource.extend_from_slice(&image.planes.to_le_bytes());
+        resource.extend_from_slice(&image.bit_count.to_le_bytes());
+        resource.extend_from_slice(&byte_len.to_le_bytes());
+        resource.extend_from_slice(&image_id.to_le_bytes());
+    }
+
+    Ok(resource)
+}
+
+fn read_u16(data: &[u8], offset: usize) -> Result<u16> {
+    let bytes = data
+        .get(offset..offset + 2)
+        .context("unexpected end of ICO data")?;
+    Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
+}
+
+fn read_u32(data: &[u8], offset: usize) -> Result<u32> {
+    let bytes = data
+        .get(offset..offset + 4)
+        .context("unexpected end of ICO data")?;
+    Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+}
+
+#[cfg(windows)]
+fn stamp_exe_icon_windows(exe_path: &Path, images: &[IconImage]) -> Result<()> {
+    use std::ffi::{OsStr, c_void};
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr;
+
+    type Bool = i32;
+    type Handle = *mut c_void;
+
+    unsafe extern "system" {
+        fn BeginUpdateResourceW(p_file_name: *const u16, delete_existing: Bool) -> Handle;
+        fn UpdateResourceW(
+            update: Handle,
+            resource_type: *const u16,
+            name: *const u16,
+            language: u16,
+            data: *mut c_void,
+            data_size: u32,
+        ) -> Bool;
+        fn EndUpdateResourceW(update: Handle, discard: Bool) -> Bool;
+    }
+
+    fn wide_os(value: &OsStr) -> Vec<u16> {
+        value.encode_wide().chain(std::iter::once(0)).collect()
+    }
+
+    fn make_int_resource(id: u16) -> *const u16 {
+        id as usize as *const u16
+    }
+
+    struct UpdateGuard(Handle);
+
+    impl Drop for UpdateGuard {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                unsafe {
+                    let _ = EndUpdateResourceW(self.0, 1);
+                }
+            }
+        }
+    }
+
+    let exe_wide = wide_os(exe_path.as_os_str());
+    let update = unsafe { BeginUpdateResourceW(exe_wide.as_ptr(), 0) };
+    if update.is_null() {
+        return Err(std::io::Error::last_os_error()).context("BeginUpdateResourceW failed");
+    }
+    let mut guard = UpdateGuard(update);
+
+    for (index, image) in images.iter().enumerate() {
+        let image_id = u16::try_from(index)
+            .ok()
+            .and_then(|v| v.checked_add(FIRST_IMAGE_ID))
+            .context("too many ICO images for resource ids")?;
+        let byte_len = u32::try_from(image.bytes.len()).context("icon image is too large")?;
+        let ok = unsafe {
+            UpdateResourceW(
+                guard.0,
+                make_int_resource(RT_ICON),
+                make_int_resource(image_id),
+                0,
+                image.bytes.as_ptr() as *mut c_void,
+                byte_len,
+            )
+        };
+        if ok == 0 {
+            return Err(std::io::Error::last_os_error())
+                .context("UpdateResourceW failed for RT_ICON");
+        }
+    }
+
+    let mut group_resource = build_group_icon_resource(images)?;
+    let group_len =
+        u32::try_from(group_resource.len()).context("group icon resource is too large")?;
+    let ok = unsafe {
+        UpdateResourceW(
+            guard.0,
+            make_int_resource(RT_GROUP_ICON),
+            make_int_resource(MAIN_ICON_ID),
+            0,
+            group_resource.as_mut_ptr() as *mut c_void,
+            group_len,
+        )
+    };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error())
+            .context("UpdateResourceW failed for RT_GROUP_ICON");
+    }
+
+    let ok = unsafe { EndUpdateResourceW(guard.0, 0) };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error()).context("EndUpdateResourceW failed");
+    }
+    guard.0 = ptr::null_mut();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn single_icon_bytes() -> Vec<u8> {
+        let image = [0x89, b'P', b'N', b'G'];
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.push(16);
+        bytes.push(16);
+        bytes.push(0);
+        bytes.push(0);
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&32u16.to_le_bytes());
+        bytes.extend_from_slice(&(image.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&(22u32).to_le_bytes());
+        bytes.extend_from_slice(&image);
+        bytes
+    }
+
+    #[test]
+    fn parse_ico_reads_single_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let icon_path = dir.path().join("app.ico");
+        fs::write(&icon_path, single_icon_bytes()).unwrap();
+
+        let images = parse_ico(&icon_path).unwrap();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].width, 16);
+        assert_eq!(images[0].height, 16);
+        assert_eq!(images[0].planes, 1);
+        assert_eq!(images[0].bit_count, 32);
+        assert_eq!(images[0].bytes, vec![0x89, b'P', b'N', b'G']);
+    }
+
+    #[test]
+    fn build_group_icon_resource_uses_resource_ids() {
+        let images = vec![IconImage {
+            width: 32,
+            height: 32,
+            color_count: 0,
+            reserved: 0,
+            planes: 1,
+            bit_count: 32,
+            bytes: vec![1, 2, 3, 4],
+        }];
+
+        let resource = build_group_icon_resource(&images).unwrap();
+        assert_eq!(&resource[0..6], &[0, 0, 1, 0, 1, 0]);
+        assert_eq!(resource[6], 32);
+        assert_eq!(resource[7], 32);
+        assert_eq!(&resource[14..18], &[4, 0, 0, 0]);
+        assert_eq!(&resource[18..20], &[1, 0]);
+    }
+}

--- a/cli/src/commands/windows_exe_icon.rs
+++ b/cli/src/commands/windows_exe_icon.rs
@@ -9,6 +9,9 @@ const RT_ICON: u16 = 3;
 const RT_GROUP_ICON: u16 = 14;
 #[cfg(windows)]
 const MAIN_ICON_ID: u16 = 1;
+// Used by `stamp_exe_icon_windows` (Windows-only) and by tests; allow it to be
+// unused on a non-Windows, non-test build.
+#[cfg_attr(not(windows), allow(dead_code))]
 const FIRST_IMAGE_ID: u16 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,6 +96,9 @@ fn parse_ico(icon_path: &Path) -> Result<Vec<IconImage>> {
     Ok(images)
 }
 
+// Used by `stamp_exe_icon_windows` (Windows-only) and by tests; allow it to be
+// unused on a non-Windows, non-test build.
+#[cfg_attr(not(windows), allow(dead_code))]
 fn build_group_icon_resource(images: &[IconImage]) -> Result<Vec<u8>> {
     let count = u16::try_from(images.len()).context("too many ICO images")?;
     let capacity = 6usize

--- a/cli/src/commands/windows_exe_icon.rs
+++ b/cli/src/commands/windows_exe_icon.rs
@@ -191,6 +191,8 @@ fn stamp_exe_icon_windows(exe_path: &Path, images: &[IconImage]) -> Result<()> {
     }
 
     let exe_wide = wide_os(exe_path.as_os_str());
+    // `0` keeps existing resources; the Zig runtime exe ships with no icon
+    // resources, so there is nothing to purge.
     let update = unsafe { BeginUpdateResourceW(exe_wide.as_ptr(), 0) };
     if update.is_null() {
         return Err(std::io::Error::last_os_error()).context("BeginUpdateResourceW failed");
@@ -237,11 +239,14 @@ fn stamp_exe_icon_windows(exe_path: &Path, images: &[IconImage]) -> Result<()> {
             .context("UpdateResourceW failed for RT_GROUP_ICON");
     }
 
-    let ok = unsafe { EndUpdateResourceW(guard.0, 0) };
+    // Detach the guard before committing: EndUpdateResourceW closes the handle
+    // even on failure, so Drop must not call it a second time.
+    let handle = guard.0;
+    guard.0 = ptr::null_mut();
+    let ok = unsafe { EndUpdateResourceW(handle, 0) };
     if ok == 0 {
         return Err(std::io::Error::last_os_error()).context("EndUpdateResourceW failed");
     }
-    guard.0 = ptr::null_mut();
 
     Ok(())
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -913,6 +913,25 @@ fn write_ghostty_value(out: &mut String, key: &str, value: &toml::Value) {
 // C ABI — used by the Zig/Swift runtimes
 // ---------------------------------------------------------------------------
 
+/// Single source of truth for the bundled Windows icon filename; reached only
+/// through the two accessors below, so the packager and runtime can't drift.
+const WINDOWS_ICON_FILENAME: &CStr = c"app.ico";
+
+/// The bundled Windows icon filename as a Rust `&str` (no trailing NUL), used by
+/// the packager to name and report the bundled icon. The Zig runtime reads the
+/// same name through [`trolley_windows_icon_filename`].
+pub fn windows_icon_filename_str() -> &'static str {
+    WINDOWS_ICON_FILENAME.to_str().expect("WINDOWS_ICON_FILENAME is ASCII")
+}
+
+/// C/Zig accessor: the bundled Windows icon filename as a NUL-terminated string.
+/// The Rust packager reads the same name through [`windows_icon_filename_str`].
+/// Zig: `std.mem.span(trolley.trolley_windows_icon_filename())`.
+#[unsafe(no_mangle)]
+pub extern "C" fn trolley_windows_icon_filename() -> *const c_char {
+    WINDOWS_ICON_FILENAME.as_ptr()
+}
+
 #[repr(C)]
 pub struct TrolleyGuiConfig {
     /// Initial width in pixels. 0 = unset.

--- a/runtime/src/platform/windows.zig
+++ b/runtime/src/platform/windows.zig
@@ -36,7 +36,17 @@ const WM_MBUTTONUP = 0x0208;
 const WM_MOUSEHWHEEL = 0x020E;
 const WM_GETMINMAXINFO = 0x0024;
 const WM_ERASEBKGND = 0x0014;
+const WM_SETICON = 0x0080;
 const QS_ALLINPUT = 0x04FF;
+const ICON_SMALL: usize = 0;
+const ICON_BIG: usize = 1;
+const IMAGE_ICON: u32 = 1;
+const LR_LOADFROMFILE: u32 = 0x00000010;
+const SM_CXICON = 11;
+const SM_CYICON = 12;
+const SM_CXSMICON = 49;
+const SM_CYSMICON = 50;
+const BUNDLED_WINDOW_ICON_FILENAME = "app.ico";
 
 const MINMAXINFO = extern struct {
     ptReserved: foundation.POINT,
@@ -61,9 +71,20 @@ extern "user32" fn PostMessageW(
     lParam: LPARAM,
 ) callconv(.winapi) BOOL;
 
+extern "user32" fn SendMessageW(
+    hWnd: ?HWND,
+    Msg: u32,
+    wParam: WPARAM,
+    lParam: LPARAM,
+) callconv(.winapi) LRESULT;
+
 extern "user32" fn GetDpiForWindow(
     hwnd: HWND,
 ) callconv(.winapi) u32;
+
+extern "user32" fn GetSystemMetrics(
+    nIndex: i32,
+) callconv(.winapi) i32;
 
 extern "user32" fn AdjustWindowRectEx(
     lpRect: *foundation.RECT,
@@ -91,6 +112,15 @@ extern "user32" fn SetProcessDpiAwarenessContext(
 
 extern "kernel32" fn GetModuleHandleW(
     lpModuleName: ?[*:0]const u16,
+) callconv(.winapi) ?*anyopaque;
+
+extern "user32" fn LoadImageW(
+    hInst: ?*anyopaque,
+    name: [*:0]const u16,
+    @"type": u32,
+    cx: i32,
+    cy: i32,
+    fuLoad: u32,
 ) callconv(.winapi) ?*anyopaque;
 
 extern "kernel32" fn ExitProcess(
@@ -188,6 +218,8 @@ var g_hglrc: ?HGLRC = null;
 var g_surface: ghostty.ghostty_surface_t = null;
 var g_app: ghostty.ghostty_app_t = null;
 var g_opengl32: ?*anyopaque = null;
+var g_window_icon_big: ?wam.HICON = null;
+var g_window_icon_small: ?wam.HICON = null;
 
 // Window config from trolley manifest
 var g_window_config: trolley.TrolleyGuiConfig = .{
@@ -199,6 +231,28 @@ var g_window_config: trolley.TrolleyGuiConfig = .{
     .max_width = 0,
     .max_height = 0,
 };
+
+fn loadBundledWindowIcon(width: i32, height: i32) ?wam.HICON {
+    const path = common.getBundledPath(BUNDLED_WINDOW_ICON_FILENAME) orelse return null;
+    defer std.heap.page_allocator.free(path);
+
+    const wide_path = std.unicode.utf8ToUtf16LeAllocZ(std.heap.page_allocator, path) catch return null;
+    defer std.heap.page_allocator.free(wide_path);
+
+    const handle = LoadImageW(null, wide_path, IMAGE_ICON, width, height, LR_LOADFROMFILE) orelse return null;
+    return @ptrCast(handle);
+}
+
+fn applyWindowIcons(hwnd: HWND) void {
+    if (g_window_icon_big) |icon| {
+        _ = SendMessageW(hwnd, WM_SETICON, ICON_BIG, @as(LPARAM, @intCast(@intFromPtr(icon))));
+    }
+    if (g_window_icon_small) |icon| {
+        _ = SendMessageW(hwnd, WM_SETICON, ICON_SMALL, @as(LPARAM, @intCast(@intFromPtr(icon))));
+    } else if (g_window_icon_big) |icon| {
+        _ = SendMessageW(hwnd, WM_SETICON, ICON_SMALL, @as(LPARAM, @intCast(@intFromPtr(icon))));
+    }
+}
 
 // ---------------------------------------------------------------------------
 // WGL ↔ ghostty OpenGL context bridge
@@ -865,6 +919,8 @@ pub fn main() !void {
 
     const initial_width: i32 = if (g_window_config.initial_width > 0) @intCast(g_window_config.initial_width) else 800;
     const initial_height: i32 = if (g_window_config.initial_height > 0) @intCast(g_window_config.initial_height) else 600;
+    g_window_icon_big = loadBundledWindowIcon(GetSystemMetrics(SM_CXICON), GetSystemMetrics(SM_CYICON));
+    g_window_icon_small = loadBundledWindowIcon(GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON));
 
     // -- Register window class --
     const hinstance: ?*anyopaque = GetModuleHandleW(null);
@@ -876,7 +932,7 @@ pub fn main() !void {
         .cbClsExtra = 0,
         .cbWndExtra = 0,
         .hInstance = @ptrCast(hinstance),
-        .hIcon = null,
+        .hIcon = g_window_icon_big,
         .hCursor = wam.LoadCursorW(null, wam.IDC_ARROW),
         .hbrBackground = null,
         .lpszMenuName = null,
@@ -921,6 +977,7 @@ pub fn main() !void {
     ) orelse return error.CreateWindowFailed;
 
     g_hwnd = hwnd;
+    applyWindowIcons(hwnd);
 
     // -- Create modern OpenGL context --
     const gl_ctx = try createModernGLContext(hwnd);

--- a/runtime/src/platform/windows.zig
+++ b/runtime/src/platform/windows.zig
@@ -36,7 +36,17 @@ const WM_MBUTTONUP = 0x0208;
 const WM_MOUSEHWHEEL = 0x020E;
 const WM_GETMINMAXINFO = 0x0024;
 const WM_ERASEBKGND = 0x0014;
+const WM_SETICON = 0x0080;
 const QS_ALLINPUT = 0x04FF;
+const ICON_SMALL: usize = 0;
+const ICON_BIG: usize = 1;
+const IMAGE_ICON: u32 = 1;
+const LR_LOADFROMFILE: u32 = 0x00000010;
+const SM_CXICON = 11;
+const SM_CYICON = 12;
+const SM_CXSMICON = 49;
+const SM_CYSMICON = 50;
+const BUNDLED_WINDOW_ICON_FILENAME = "app.ico";
 
 const MINMAXINFO = extern struct {
     ptReserved: foundation.POINT,
@@ -61,9 +71,20 @@ extern "user32" fn PostMessageW(
     lParam: LPARAM,
 ) callconv(.winapi) BOOL;
 
+extern "user32" fn SendMessageW(
+    hWnd: ?HWND,
+    Msg: u32,
+    wParam: WPARAM,
+    lParam: LPARAM,
+) callconv(.winapi) LRESULT;
+
 extern "user32" fn GetDpiForWindow(
     hwnd: HWND,
 ) callconv(.winapi) u32;
+
+extern "user32" fn GetSystemMetrics(
+    nIndex: i32,
+) callconv(.winapi) i32;
 
 extern "user32" fn AdjustWindowRectEx(
     lpRect: *foundation.RECT,
@@ -91,6 +112,15 @@ extern "user32" fn SetProcessDpiAwarenessContext(
 
 extern "kernel32" fn GetModuleHandleW(
     lpModuleName: ?[*:0]const u16,
+) callconv(.winapi) ?*anyopaque;
+
+extern "user32" fn LoadImageW(
+    hInst: ?*anyopaque,
+    name: [*:0]const u16,
+    @"type": u32,
+    cx: i32,
+    cy: i32,
+    fuLoad: u32,
 ) callconv(.winapi) ?*anyopaque;
 
 extern "kernel32" fn ExitProcess(
@@ -196,6 +226,8 @@ var g_hglrc: ?HGLRC = null;
 var g_surface: ghostty.ghostty_surface_t = null;
 var g_app: ghostty.ghostty_app_t = null;
 var g_opengl32: ?*anyopaque = null;
+var g_window_icon_big: ?wam.HICON = null;
+var g_window_icon_small: ?wam.HICON = null;
 
 // Window config from trolley manifest
 var g_window_config: trolley.TrolleyGuiConfig = .{
@@ -208,6 +240,28 @@ var g_window_config: trolley.TrolleyGuiConfig = .{
     .max_height = 0,
     .win_precise_timer = 1,
 };
+
+fn loadBundledWindowIcon(width: i32, height: i32) ?wam.HICON {
+    const path = common.getBundledPath(BUNDLED_WINDOW_ICON_FILENAME) orelse return null;
+    defer std.heap.page_allocator.free(path);
+
+    const wide_path = std.unicode.utf8ToUtf16LeAllocZ(std.heap.page_allocator, path) catch return null;
+    defer std.heap.page_allocator.free(wide_path);
+
+    const handle = LoadImageW(null, wide_path, IMAGE_ICON, width, height, LR_LOADFROMFILE) orelse return null;
+    return @ptrCast(handle);
+}
+
+fn applyWindowIcons(hwnd: HWND) void {
+    if (g_window_icon_big) |icon| {
+        _ = SendMessageW(hwnd, WM_SETICON, ICON_BIG, @as(LPARAM, @intCast(@intFromPtr(icon))));
+    }
+    if (g_window_icon_small) |icon| {
+        _ = SendMessageW(hwnd, WM_SETICON, ICON_SMALL, @as(LPARAM, @intCast(@intFromPtr(icon))));
+    } else if (g_window_icon_big) |icon| {
+        _ = SendMessageW(hwnd, WM_SETICON, ICON_SMALL, @as(LPARAM, @intCast(@intFromPtr(icon))));
+    }
+}
 
 // ---------------------------------------------------------------------------
 // WGL ↔ ghostty OpenGL context bridge
@@ -879,6 +933,8 @@ pub fn main() !void {
 
     const initial_width: i32 = if (g_window_config.initial_width > 0) @intCast(g_window_config.initial_width) else 800;
     const initial_height: i32 = if (g_window_config.initial_height > 0) @intCast(g_window_config.initial_height) else 600;
+    g_window_icon_big = loadBundledWindowIcon(GetSystemMetrics(SM_CXICON), GetSystemMetrics(SM_CYICON));
+    g_window_icon_small = loadBundledWindowIcon(GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON));
 
     // -- Register window class --
     const hinstance: ?*anyopaque = GetModuleHandleW(null);
@@ -890,7 +946,7 @@ pub fn main() !void {
         .cbClsExtra = 0,
         .cbWndExtra = 0,
         .hInstance = @ptrCast(hinstance),
-        .hIcon = null,
+        .hIcon = g_window_icon_big,
         .hCursor = wam.LoadCursorW(null, wam.IDC_ARROW),
         .hbrBackground = null,
         .lpszMenuName = null,
@@ -935,6 +991,7 @@ pub fn main() !void {
     ) orelse return error.CreateWindowFailed;
 
     g_hwnd = hwnd;
+    applyWindowIcons(hwnd);
 
     // -- Create modern OpenGL context --
     const gl_ctx = try createModernGLContext(hwnd);

--- a/runtime/src/platform/windows.zig
+++ b/runtime/src/platform/windows.zig
@@ -46,7 +46,6 @@ const SM_CXICON = 11;
 const SM_CYICON = 12;
 const SM_CXSMICON = 49;
 const SM_CYSMICON = 50;
-const BUNDLED_WINDOW_ICON_FILENAME = "app.ico";
 
 const MINMAXINFO = extern struct {
     ptReserved: foundation.POINT,
@@ -242,7 +241,8 @@ var g_window_config: trolley.TrolleyGuiConfig = .{
 };
 
 fn loadBundledWindowIcon(width: i32, height: i32) ?wam.HICON {
-    const path = common.getBundledPath(BUNDLED_WINDOW_ICON_FILENAME) orelse return null;
+    const icon_filename = std.mem.span(trolley.trolley_windows_icon_filename());
+    const path = common.getBundledPath(icon_filename) orelse return null;
     defer std.heap.page_allocator.free(path);
 
     const wide_path = std.unicode.utf8ToUtf16LeAllocZ(std.heap.page_allocator, path) catch return null;

--- a/runtime/src/platform/windows.zig
+++ b/runtime/src/platform/windows.zig
@@ -254,12 +254,12 @@ fn loadBundledWindowIcon(width: i32, height: i32) ?wam.HICON {
 
 fn applyWindowIcons(hwnd: HWND) void {
     if (g_window_icon_big) |icon| {
-        _ = SendMessageW(hwnd, WM_SETICON, ICON_BIG, @as(LPARAM, @intCast(@intFromPtr(icon))));
+        _ = SendMessageW(hwnd, WM_SETICON, ICON_BIG, @as(LPARAM, @bitCast(@intFromPtr(icon))));
     }
     if (g_window_icon_small) |icon| {
-        _ = SendMessageW(hwnd, WM_SETICON, ICON_SMALL, @as(LPARAM, @intCast(@intFromPtr(icon))));
+        _ = SendMessageW(hwnd, WM_SETICON, ICON_SMALL, @as(LPARAM, @bitCast(@intFromPtr(icon))));
     } else if (g_window_icon_big) |icon| {
-        _ = SendMessageW(hwnd, WM_SETICON, ICON_SMALL, @as(LPARAM, @intCast(@intFromPtr(icon))));
+        _ = SendMessageW(hwnd, WM_SETICON, ICON_SMALL, @as(LPARAM, @bitCast(@intFromPtr(icon))));
     }
 }
 


### PR DESCRIPTION
This PR implements two aspects of .ico embedding for the Windows runtime:
* Embeds the .ico file into the `_runtime.exe` as a Windows resource so when viewing the .exe on disk, you see the icon.
* The `_runtime.exe` calls native Windows API to set the titlebar icon as well.

Here is a visual example (ignore that the embedded .exe icon looks different from the titlebar one, it's due to windows caching an old icon I had tried):
<img width="399" height="448" alt="image" src="https://github.com/user-attachments/assets/228fb747-f6e5-4075-9016-ff8311bceed7" />
