### PR TITLE
feat: add file drag-and-drop for all platforms

### DIFF
--- a/runtime/macos/Sources/main.swift
+++ b/runtime/macos/Sources/main.swift
@@ -222,6 +222,7 @@ class TrolleyView: NSView, NSTextInputClient {
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
+        registerForDraggedTypes([.fileURL])
     }
 
     required init?(coder: NSCoder) {
@@ -438,6 +439,38 @@ class TrolleyView: NSView, NSTextInputClient {
         }
         mods |= Int32(momentum) << 1
         ghostty_surface_mouse_scroll(surface, x, y, mods)
+    }
+
+    // MARK: - Drag and drop
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        if sender.draggingPasteboard.canReadObject(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) {
+            return .copy
+        }
+        return []
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let surface = gSurface else { return false }
+        guard let urls = sender.draggingPasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] else { return false }
+
+        let paths = urls.map { shellEscape($0.path) }
+        let text = paths.joined(separator: " ")
+
+        text.withCString { ptr in
+            ghostty_surface_text(surface, ptr, text.utf8.count)
+        }
+        return true
+    }
+
+    private func shellEscape(_ path: String) -> String {
+        if path.rangeOfCharacter(from: .init(charactersIn: " \t'\"\\!$`#&|;(){}[]<>?*~")) != nil {
+            return "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        }
+        return path
     }
 }
 

--- a/runtime/src/platform/linux.zig
+++ b/runtime/src/platform/linux.zig
@@ -346,6 +346,85 @@ fn contentScaleCallback(_: ?*glfw.GLFWwindow, xscale: f32, yscale: f32) callconv
     ghostty.ghostty_surface_set_content_scale(surface, xscale, yscale);
 }
 
+fn dropCallback(_: ?*glfw.GLFWwindow, count: c_int, paths: [*c]const [*c]const u8) callconv(.c) void {
+    const surface = g_surface orelse return;
+    if (count <= 0) return;
+
+    var buf: [8192]u8 = undefined;
+    var pos: usize = 0;
+
+    const n: usize = @intCast(count);
+    for (0..n) |i| {
+        if (i > 0) {
+            if (pos >= buf.len) break;
+            buf[pos] = ' ';
+            pos += 1;
+        }
+        const path = std.mem.span(paths[i]);
+        const escaped_len = shellEscapeLen(path);
+        if (pos + escaped_len > buf.len) break;
+        pos = shellEscapeInto(&buf, pos, path);
+    }
+
+    if (pos > 0) {
+        ghostty.ghostty_surface_text(surface, &buf, pos);
+    }
+}
+
+fn shellEscapeLen(path: []const u8) usize {
+    if (!needsEscape(path)) return path.len;
+    // Quoted form: opening ' + content (each ' becomes '\'' = 4 chars) + closing '
+    var len: usize = 2; // quotes
+    for (path) |c| {
+        len += if (c == '\'') 4 else 1;
+    }
+    return len;
+}
+
+fn shellEscapeInto(buf: []u8, start: usize, path: []const u8) usize {
+    var pos = start;
+    if (!needsEscape(path)) {
+        for (path) |c| {
+            if (pos >= buf.len) break;
+            buf[pos] = c;
+            pos += 1;
+        }
+        return pos;
+    }
+    if (pos >= buf.len) return pos;
+    buf[pos] = '\'';
+    pos += 1;
+    for (path) |c| {
+        if (c == '\'') {
+            // '\'' — end quote, escaped single quote, start quote
+            const esc = "'\\''";
+            for (esc) |e| {
+                if (pos >= buf.len) return pos;
+                buf[pos] = e;
+                pos += 1;
+            }
+        } else {
+            if (pos >= buf.len) return pos;
+            buf[pos] = c;
+            pos += 1;
+        }
+    }
+    if (pos >= buf.len) return pos;
+    buf[pos] = '\'';
+    pos += 1;
+    return pos;
+}
+
+fn needsEscape(path: []const u8) bool {
+    const special = " \t'\"\\!$`#&|;(){}[]<>?*~";
+    for (path) |c| {
+        for (special) |s| {
+            if (c == s) return true;
+        }
+    }
+    return false;
+}
+
 fn translateMods(glfw_mods: c_int) ghostty.ghostty_input_mods_e {
     var mods: c_int = ghostty.GHOSTTY_MODS_NONE;
     if (glfw_mods & glfw.GLFW_MOD_SHIFT != 0) mods |= ghostty.GHOSTTY_MODS_SHIFT;
@@ -527,6 +606,7 @@ pub fn main() !void {
     _ = glfw.glfwSetFramebufferSizeCallback(window, &framebufferSizeCallback);
     _ = glfw.glfwSetWindowFocusCallback(window, &focusCallback);
     _ = glfw.glfwSetWindowContentScaleCallback(window, &contentScaleCallback);
+    _ = glfw.glfwSetDropCallback(window, &dropCallback);
 
     // -- Event loop --
     while (glfw.glfwWindowShouldClose(window) != glfw.GLFW_TRUE) {

--- a/runtime/src/platform/windows.zig
+++ b/runtime/src/platform/windows.zig
@@ -36,6 +36,7 @@ const WM_MBUTTONUP = 0x0208;
 const WM_MOUSEHWHEEL = 0x020E;
 const WM_GETMINMAXINFO = 0x0024;
 const WM_ERASEBKGND = 0x0014;
+const WM_DROPFILES = 0x0233;
 const QS_ALLINPUT = 0x04FF;
 
 const MINMAXINFO = extern struct {
@@ -104,6 +105,22 @@ extern "winmm" fn timeBeginPeriod(
 extern "winmm" fn timeEndPeriod(
     uPeriod: u32,
 ) callconv(.winapi) u32;
+
+extern "shell32" fn DragAcceptFiles(
+    hWnd: HWND,
+    fAccept: BOOL,
+) callconv(.winapi) void;
+
+extern "shell32" fn DragQueryFileW(
+    hDrop: ?*anyopaque,
+    iFile: u32,
+    lpszFile: ?[*]u16,
+    cch: u32,
+) callconv(.winapi) u32;
+
+extern "shell32" fn DragFinish(
+    hDrop: ?*anyopaque,
+) callconv(.winapi) void;
 
 extern "opengl32" fn wglGetProcAddress(
     lpszProc: [*:0]const u8,
@@ -738,6 +755,39 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
             // Suppress GDI background erase — OpenGL handles all rendering
             return 1;
         },
+        WM_DROPFILES => {
+            const surface = g_surface orelse return wam.DefWindowProcW(hwnd, msg, wParam, lParam);
+            const hDrop: ?*anyopaque = @ptrFromInt(@as(usize, @bitCast(wParam)));
+            defer DragFinish(hDrop);
+            const count = DragQueryFileW(hDrop, 0xFFFFFFFF, null, 0);
+            if (count == 0) return 0;
+
+            var buf: [8192]u8 = undefined;
+            var pos: usize = 0;
+            var path_buf: [1024]u16 = undefined;
+
+            for (0..count) |i| {
+                if (i > 0) {
+                    if (pos >= buf.len) break;
+                    buf[pos] = ' ';
+                    pos += 1;
+                }
+                const len = DragQueryFileW(hDrop, @intCast(i), &path_buf, path_buf.len);
+                if (len == 0) continue;
+                // Convert UTF-16 path to UTF-8
+                var utf8_path: [4096]u8 = undefined;
+                const utf8_len = std.unicode.utf16LeToUtf8(&utf8_path, path_buf[0..len]) catch continue;
+                const path = utf8_path[0..utf8_len];
+                const escaped_len = shellEscapeLen(path);
+                if (pos + escaped_len > buf.len) break;
+                pos = shellEscapeInto(&buf, pos, path);
+            }
+
+            if (pos > 0) {
+                ghostty.ghostty_surface_text(surface, &buf, pos);
+            }
+            return 0;
+        },
         wam.WM_DESTROY => {
             wam.PostQuitMessage(0);
             return 0;
@@ -748,6 +798,61 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
         },
         else => return wam.DefWindowProcW(hwnd, msg, wParam, lParam),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Shell escaping for drag-and-drop paths
+// ---------------------------------------------------------------------------
+fn shellEscapeLen(path: []const u8) usize {
+    if (!needsEscape(path)) return path.len;
+    var len: usize = 2; // opening and closing quotes
+    for (path) |c| {
+        len += if (c == '\'') 4 else 1;
+    }
+    return len;
+}
+
+fn shellEscapeInto(buf: []u8, start: usize, path: []const u8) usize {
+    var pos = start;
+    if (!needsEscape(path)) {
+        for (path) |c| {
+            if (pos >= buf.len) break;
+            buf[pos] = c;
+            pos += 1;
+        }
+        return pos;
+    }
+    if (pos >= buf.len) return pos;
+    buf[pos] = '\'';
+    pos += 1;
+    for (path) |c| {
+        if (c == '\'') {
+            const esc = "'\\''";
+            for (esc) |e| {
+                if (pos >= buf.len) return pos;
+                buf[pos] = e;
+                pos += 1;
+            }
+        } else {
+            if (pos >= buf.len) return pos;
+            buf[pos] = c;
+            pos += 1;
+        }
+    }
+    if (pos >= buf.len) return pos;
+    buf[pos] = '\'';
+    pos += 1;
+    return pos;
+}
+
+fn needsEscape(path: []const u8) bool {
+    const special = " \t'\"\\!$`#&|;(){}[]<>?*~";
+    for (path) |c| {
+        for (special) |s| {
+            if (c == s) return true;
+        }
+    }
+    return false;
 }
 
 // Path resolution delegated to common module:
@@ -935,6 +1040,7 @@ pub fn main() !void {
     ) orelse return error.CreateWindowFailed;
 
     g_hwnd = hwnd;
+    DragAcceptFiles(hwnd, TRUE);
 
     // -- Create modern OpenGL context --
     const gl_ctx = try createModernGLContext(hwnd);


### PR DESCRIPTION
Hi, I'm Charlie. It should come as no surprise that the PR here was created by Claude– I hope it comes off as ignorance rather than laziness. For context, this PR and https://github.com/weedonandscott/trolley/pull/30 are part of an effort to turn https://github.com/chardigio/pappardelle into a Mac app. If there's anything else I can do to help with your job of QAing / merging here just let me know.

## Summary

- Adds file drag-and-drop support for **macOS**, **Linux**, and **Windows**
- Dragged files have their shell-escaped paths pasted into the terminal
- Uses `ghostty_surface_text` for safe paste-like text transfer (not individual key events)

Split from #24 per review feedback.

### Platform implementations

| Platform | Mechanism |
|----------|-----------|
| macOS | `NSDraggingDestination` protocol on `TrolleyView` |
| Linux | GLFW `glfwSetDropCallback` |
| Windows | `DragAcceptFiles` + `WM_DROPFILES` with `DragQueryFileW` |

All platforms share the same behavior: shell-escape each path (single-quote wrapping for paths containing special characters), join with spaces, and send to the terminal via `ghostty_surface_text`.

### Changes

- **`runtime/macos/Sources/main.swift`** — Register for `.fileURL` drag type, implement `draggingEntered`/`performDragOperation`, shell escape helper
- **`runtime/src/platform/linux.zig`** — `dropCallback` via GLFW, shell escape helpers, register callback
- **`runtime/src/platform/windows.zig`** — `WM_DROPFILES` handler, shell32 `DragAcceptFiles`/`DragQueryFileW`/`DragFinish` externs, UTF-16→UTF-8 path conversion, shell escape helpers

### Reviewer feedback addressed (from #24)

1. ✅ Implemented for all platforms (macOS, Linux, Windows), not just macOS
2. ✅ Uses `ghostty_surface_text` for safe text transfer instead of individual key events

## Code Review Summary

**Strengths:**
- Cross-platform consistency with identical shell escaping across all platforms
- Defensive buffer management with bounds checking to prevent overflows
- Proper error handling (null surface checks, UTF-16 conversion error handling)
- Clean implementation of platform-specific APIs (NSDraggingDestination, GLFW callbacks, Windows drag-and-drop)
- Safe resource cleanup (e.g., Windows `DragFinish` in defer block)

**Notes:**
- Fixed 8192-byte buffer used for dropped paths — gracefully stops adding files if exceeded, but consider this when testing with many/long filenames
- Shell escaping uses standard POSIX single-quote technique, covers common metacharacters

## Test plan

- [ ] macOS: Drag file from Finder onto terminal — path appears at cursor
- [ ] macOS: Drag file with spaces in name — path is single-quoted
- [ ] macOS: Drag multiple files — space-separated escaped paths
- [ ] Linux: Drag file from file manager onto terminal
- [ ] Linux: Verify paths with special characters are escaped
- [ ] Windows: Drag file from Explorer onto terminal
- [ ] Windows: Verify UTF-16 paths (non-ASCII filenames) work correctly
- [ ] All platforms: Verify no crash when dropping with no active surface
- [ ] Manual verification: Confirm dropped paths work in shell commands (e.g., can cd into a dragged directory)