### PR TITLE
Add signing functionality for Windows and Mac packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,72 @@ binaries = { x86_64 = "path/to/app.exe" }
 precise_timer = false
 ```
 
+#### Code signing -- optional
+
+`[macos]` and `[windows]` accept a `signing` table. It holds only **non-secret
+selectors** -- all secret material (certificates, passwords, API keys, Azure
+credentials) is read from the **environment** at build time, so nothing secret
+goes in `trolley.toml`. Signing applies to the `nsis` (Windows) and `app`/`dmg`
+(macOS) formats.
+
+```toml
+[macos]
+binaries = { aarch64 = "...", x86_64 = "..." }
+# identity is optional; omit it to take APPLE_SIGNING_IDENTITY from the env.
+signing = { identity = "Developer ID Application: ACME Inc (TEAMID)" }
+# signing = { entitlements = "app.entitlements" }   # optional extras
+# signing = { identity = "-" }                      # ad-hoc (local dev only)
+
+[windows]
+binaries = { x86_64 = "..." }
+# Local cert in the Windows store (requires a Windows build host):
+signing = { thumbprint = "A1B2C3…", timestamp_url = "http://timestamp.digicert.com" }
+# …or a custom command such as Azure Artifact Signing (works on any host,
+# required when cross-compiling Windows from Linux/macOS). `%1` = file to sign:
+# signing = { sign_command = "trusted-signing-cli -e https://wus2.codesigning.azure.net -a MyAccount -c MyProfile -d MyApp %1" }
+```
+
+`[windows.signing]` requires at least one of `thumbprint` or `sign_command`.
+When signing via `thumbprint`, `timestamp_url` is **required**: a non-timestamped
+signature becomes invalid once the certificate expires, which would invalidate
+already-released binaries. On the `sign_command` path, timestamping is the
+command's job (Azure Artifact Signing does it automatically). Other optional
+keys: `digest_algorithm` (default `sha256`), `tsp`. macOS signatures are always
+timestamped automatically.
+
+#### macOS environment variables
+
+Read from the environment at build time. All are optional — supply only what
+your signing/notarization method needs:
+
+| Purpose | Variables |
+| --- | --- |
+| Signing identity (if not set in config) | `APPLE_SIGNING_IDENTITY` |
+| Certificate on CI (else the keychain is used) | `APPLE_CERTIFICATE` (base64 `.p12`) + `APPLE_CERTIFICATE_PASSWORD` |
+| Notarization — pick one group | `APPLE_KEYCHAIN_PROFILE` · or `APPLE_ID` + `APPLE_PASSWORD` + `APPLE_TEAM_ID` · or `APPLE_API_KEY` + `APPLE_API_ISSUER` + `APPLE_API_KEY_PATH` |
+
+`APPLE_API_KEY_PATH` may be omitted if the `AuthKey_<KEY>.p8` file sits in
+`./private_keys`, `~/private_keys`, `~/.private_keys`, or
+`~/.appstoreconnect/private_keys`. A signed macOS build automatically gets the
+hardened runtime + a secure timestamp, and is notarized (then stapled) when one
+notarization group is present — otherwise it is signed but not notarized. macOS
+sign/notarize must run on a macOS host.
+
+#### Windows environment variables
+
+**trolley itself reads no Windows env vars** — all Windows signing configuration
+lives in `[windows.signing]` above. The `thumbprint` path needs none (the cert
+comes from the Windows certificate store). On the `sign_command` path, the env
+vars that matter are the ones **the tool in your command** reads, e.g.:
+
+| Tool | Variables |
+| --- | --- |
+| Azure Artifact Signing (`trusted-signing-cli`) | `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID` |
+| DigiCert KeyLocker (`smctl`/`signtool`) | `SM_HOST`, `SM_API_KEY`, `SM_CLIENT_CERT_FILE`, `SM_CLIENT_CERT_PASSWORD` |
+
+Consult your signing tool's docs for its exact variables; trolley just runs the
+command you give it.
+
 ### `[gui]` -- optional
 
 `initial_width`, `initial_height`, `resizable`, `min_width`, `min_height`,

--- a/cli/src/commands/formats/packager_common.rs
+++ b/cli/src/commands/formats/packager_common.rs
@@ -118,6 +118,50 @@ fn build_packager_config(
         packager_config.deb = Some(deb);
     }
 
+    // Code-signing: only the matching platform's config is applied. The signing structs hold
+    // non-secret selectors; cargo-packager reads cert material / notarization / Azure creds
+    // from the environment itself.
+    match manifest.variant {
+        BundleVariant::MacOs => {
+            if let Some(signing) = config.macos.as_ref().and_then(|m| m.signing.as_ref()) {
+                // Identity from config, else the APPLE_SIGNING_IDENTITY env var (Tauri parity).
+                // Drop an empty/whitespace env value so it falls through to the bail! below
+                // instead of producing a confusing `codesign -s ""`.
+                let identity = signing.identity.clone().or_else(|| {
+                    std::env::var("APPLE_SIGNING_IDENTITY")
+                        .ok()
+                        .filter(|s| !s.trim().is_empty())
+                });
+                let Some(identity) = identity else {
+                    anyhow::bail!(
+                        "[macos.signing] is set but no signing identity was found: set \
+                         `identity` in trolley.toml or the APPLE_SIGNING_IDENTITY env var"
+                    );
+                };
+                let mut macos = cargo_packager::config::MacOsConfig::default();
+                macos.signing_identity = Some(identity);
+                macos.entitlements = signing.entitlements.clone();
+                packager_config.macos = Some(macos);
+                // notarization_credentials + cert material left unset on purpose:
+                // cargo-packager reads APPLE_* / APPLE_CERTIFICATE* from the environment.
+            }
+        }
+        BundleVariant::Windows => {
+            if let Some(signing) = config.windows.as_ref().and_then(|w| w.signing.as_ref()) {
+                let mut win = cargo_packager::config::WindowsConfig::default();
+                win.certificate_thumbprint = signing.thumbprint.clone();
+                win.sign_command = signing.sign_command.clone();
+                win.timestamp_url = signing.timestamp_url.clone();
+                if let Some(digest) = &signing.digest_algorithm {
+                    win.digest_algorithm = Some(digest.clone());
+                }
+                win.tsp = signing.tsp;
+                packager_config.windows = Some(win);
+            }
+        }
+        BundleVariant::Linux { .. } => {}
+    }
+
     Ok(packager_config)
 }
 

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -47,11 +47,13 @@ pub fn run(path: Option<String>) -> Result<()> {
     let macos = Some(Macos {
         binaries: all_arches.clone(),
         args: Vec::new(),
+        signing: None,
     });
     let windows = Some(Windows {
         binaries: all_arches,
         args: Vec::new(),
         precise_timer: None,
+        signing: None,
     });
 
     let manifest = Config {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -436,6 +436,8 @@ pub struct Macos {
     pub binaries: BTreeMap<Arch, String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signing: Option<MacosSigning>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -450,6 +452,8 @@ pub struct Windows {
     /// Defaults to true; set to false to opt out.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub precise_timer: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signing: Option<WindowsSigning>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -457,6 +461,64 @@ pub struct Windows {
 pub struct AppImageConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub categories: Option<String>,
+}
+
+/// macOS code-signing / notarization settings (non-secret selectors only).
+///
+/// All secret material is read from the environment by the `cargo-packager` library at
+/// build time, so it never lives in `trolley.toml`:
+/// - cert on CI: `APPLE_CERTIFICATE` (+ `APPLE_CERTIFICATE_PASSWORD`) — auto-imported into a
+///   temporary keychain.
+/// - notarization (one set): `APPLE_KEYCHAIN_PROFILE`; or
+///   `APPLE_ID` + `APPLE_PASSWORD` + `APPLE_TEAM_ID`; or
+///   `APPLE_API_KEY` + `APPLE_API_ISSUER` + `APPLE_API_KEY_PATH`.
+///
+/// Codesigning automatically enables the hardened runtime + a secure timestamp, so a signed
+/// build is notarization-eligible. Setting `identity = "-"` produces an ad-hoc signature
+/// (local dev only — still Gatekeeper-warned, never notarized).
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MacosSigning {
+    /// Signing identity, e.g. `"Developer ID Application: ACME Inc (TEAMID)"`.
+    ///
+    /// Optional: when omitted, the `APPLE_SIGNING_IDENTITY` environment variable is used at
+    /// build time instead (so CI can sign without editing config).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<String>,
+    /// Optional path to an entitlements `.plist` (passed to `codesign --entitlements`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entitlements: Option<String>,
+}
+
+/// Windows Authenticode signing settings (non-secret selectors only).
+///
+/// Provide either `thumbprint` (a cert in the Windows certificate store; requires a Windows
+/// build host) or `sign_command` (a custom tool such as Azure Artifact Signing; works on any
+/// host and is required when cross-compiling from Linux/macOS). The `sign_command` tool reads
+/// its own secrets (e.g. `AZURE_*`) from the environment.
+///
+/// When signing via `thumbprint`, `timestamp_url` is **required** — a non-timestamped
+/// signature stops being valid once the certificate expires, which would invalidate
+/// already-released binaries. On the `sign_command` path, timestamping is the command's
+/// responsibility (Azure Artifact Signing timestamps automatically).
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsSigning {
+    /// SHA-1 thumbprint of a certificate in the Windows certificate store.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thumbprint: Option<String>,
+    /// Custom signing command. `%1` is replaced with the file path to sign.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sign_command: Option<String>,
+    /// RFC3161 timestamp server URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp_url: Option<String>,
+    /// Signature digest algorithm; cargo-packager defaults to `sha256` when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest_algorithm: Option<String>,
+    /// Use the RFC3161 Time-Stamp Protocol (`signtool /tr`+`/td`) instead of `/t`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub tsp: bool,
 }
 
 /// Default environment variables always injected by trolley.
@@ -559,6 +621,16 @@ impl Config {
                 }
             }
             validate_platform_args("[macos]", &macos.args, &mut errors);
+            // identity is optional (falls back to APPLE_SIGNING_IDENTITY at build time), but
+            // an explicitly-provided one must not be blank.
+            if let Some(signing) = &macos.signing {
+                if matches!(&signing.identity, Some(id) if id.trim().is_empty()) {
+                    errors.push("[macos.signing] identity must not be empty".into());
+                }
+                if matches!(&signing.entitlements, Some(e) if e.trim().is_empty()) {
+                    errors.push("[macos.signing] entitlements must not be empty".into());
+                }
+            }
         }
         if let Some(ref windows) = self.windows {
             if windows.binaries.is_empty() {
@@ -572,6 +644,48 @@ impl Config {
                 }
             }
             validate_platform_args("[windows]", &windows.args, &mut errors);
+            // Signing needs exactly one of thumbprint / sign_command. Neither means
+            // cargo-packager cannot sign (silent unsigned installer); both means one is
+            // silently ignored (the library always prefers sign_command).
+            if let Some(signing) = &windows.signing {
+                match (&signing.thumbprint, &signing.sign_command) {
+                    (None, None) => errors.push(
+                        "[windows.signing] requires either `thumbprint` or `sign_command`".into(),
+                    ),
+                    (Some(_), Some(_)) => errors.push(
+                        "[windows.signing] set only one of `thumbprint` or `sign_command` \
+                         (cargo-packager silently prefers `sign_command` when both are present)"
+                            .into(),
+                    ),
+                    _ => {}
+                }
+                // The custom command must receive the file to sign via a standalone `%1`
+                // token; otherwise cargo-packager never passes it the file.
+                if let Some(cmd) = &signing.sign_command {
+                    if !cmd.split_whitespace().any(|t| t == "%1") {
+                        errors.push(
+                            "[windows.signing] `sign_command` must contain a `%1` token \
+                             (replaced with the file path to sign)"
+                                .into(),
+                        );
+                    }
+                }
+                // Always timestamp: the built-in signtool path (thumbprint, no custom command)
+                // only timestamps when a URL is given. A non-timestamped signature becomes
+                // invalid once the certificate expires, breaking already-released binaries.
+                // The sign_command path is opaque, so its timestamping is the command's job.
+                if signing.sign_command.is_none()
+                    && signing.thumbprint.is_some()
+                    && signing.timestamp_url.is_none()
+                {
+                    errors.push(
+                        "[windows.signing] `timestamp_url` is required when signing with \
+                         `thumbprint` (timestamped signatures stay valid after the certificate \
+                         expires)"
+                            .into(),
+                    );
+                }
+            }
         }
 
         // Window dimension checks
@@ -1172,6 +1286,213 @@ precise_timer = false
 "#;
         let manifest: Config = toml::from_str(toml_str).unwrap();
         assert!(!windows_precise_timer_enabled(&manifest));
+    }
+
+    // -----------------------------------------------------------------------
+    // Signing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_signing_sections() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[macos]
+binaries = { aarch64 = "my-app-mac" }
+signing = { identity = "Developer ID Application: ACME (TEAMID)", entitlements = "app.entitlements" }
+
+[windows]
+binaries = { x86_64 = "my-app.exe" }
+signing = { thumbprint = "A1B2C3", timestamp_url = "http://ts.example", tsp = true }
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        manifest.validate().unwrap();
+
+        let macos = manifest.macos.unwrap().signing.unwrap();
+        assert_eq!(
+            macos.identity.as_deref(),
+            Some("Developer ID Application: ACME (TEAMID)")
+        );
+        assert_eq!(macos.entitlements.as_deref(), Some("app.entitlements"));
+
+        let win = manifest.windows.unwrap().signing.unwrap();
+        assert_eq!(win.thumbprint.as_deref(), Some("A1B2C3"));
+        assert_eq!(win.sign_command, None);
+        assert_eq!(win.timestamp_url.as_deref(), Some("http://ts.example"));
+        assert!(win.tsp);
+    }
+
+    #[test]
+    fn signing_windows_sign_command_only() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[windows]
+binaries = { x86_64 = "my-app.exe" }
+signing = { sign_command = "trusted-signing-cli -e https://x -a A -c C %1" }
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        manifest.validate().unwrap();
+        let win = manifest.windows.unwrap().signing.unwrap();
+        assert!(win.thumbprint.is_none());
+        assert_eq!(
+            win.sign_command.as_deref(),
+            Some("trusted-signing-cli -e https://x -a A -c C %1")
+        );
+    }
+
+    #[test]
+    fn signing_macos_identity_optional() {
+        // A bare `signing = {}` is valid: the identity falls back to APPLE_SIGNING_IDENTITY.
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[macos]
+binaries = { aarch64 = "my-app-mac" }
+signing = {}
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        manifest.validate().unwrap();
+        let macos = manifest.macos.unwrap().signing.unwrap();
+        assert!(macos.identity.is_none());
+    }
+
+    #[test]
+    fn validate_windows_signing_requires_thumbprint_or_command() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[windows]
+binaries = { x86_64 = "my-app.exe" }
+signing = { timestamp_url = "http://ts.example" }
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        let err = manifest.validate().unwrap_err().to_string();
+        assert!(err.contains("[windows.signing]"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_windows_thumbprint_requires_timestamp() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[windows]
+binaries = { x86_64 = "my-app.exe" }
+signing = { thumbprint = "A1B2C3" }
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        let err = manifest.validate().unwrap_err().to_string();
+        assert!(err.contains("timestamp_url"), "got: {err}");
+    }
+
+    #[test]
+    fn signing_sign_command_needs_no_timestamp_url() {
+        // The custom-command path handles its own timestamping, so no timestamp_url is required.
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[windows]
+binaries = { x86_64 = "my-app.exe" }
+signing = { sign_command = "trusted-signing-cli -e https://x -a A -c C %1" }
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        manifest.validate().unwrap();
+    }
+
+    #[test]
+    fn validate_macos_signing_empty_identity() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[macos]
+binaries = { aarch64 = "my-app-mac" }
+signing = { identity = "  " }
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        let err = manifest.validate().unwrap_err().to_string();
+        assert!(err.contains("[macos.signing]"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_windows_signing_rejects_both() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[windows]
+binaries = { x86_64 = "my-app.exe" }
+signing = { thumbprint = "A1B2C3", sign_command = "tool %1", timestamp_url = "http://ts.example" }
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        let err = manifest.validate().unwrap_err().to_string();
+        assert!(err.contains("only one"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_windows_sign_command_requires_placeholder() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[windows]
+binaries = { x86_64 = "my-app.exe" }
+signing = { sign_command = "trusted-signing-cli -e https://x -a A -c C" }
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        let err = manifest.validate().unwrap_err().to_string();
+        assert!(err.contains("%1"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_macos_signing_empty_entitlements() {
+        let toml_str = r#"
+[app]
+identifier = "com.example.test"
+display_name = "Test"
+slug = "test"
+version = "1.0.0"
+
+[macos]
+binaries = { aarch64 = "my-app-mac" }
+signing = { identity = "Developer ID Application: ACME (TEAM)", entitlements = "  " }
+"#;
+        let manifest: Config = toml::from_str(toml_str).unwrap();
+        let err = manifest.validate().unwrap_err().to_string();
+        assert!(err.contains("[macos.signing]"), "got: {err}");
     }
 
     // -----------------------------------------------------------------------

--- a/examples/hello/trolley.toml
+++ b/examples/hello/trolley.toml
@@ -9,9 +9,13 @@ binaries = { x86_64 = "zig-out/bin/hello" }
 
 [macos]
 binaries = { aarch64 = "zig-out/bin/hello", x86_64 = "zig-out/bin/hello" }
+# Code signing (see README). Secrets come from the environment, not here:
+# signing = { identity = "Developer ID Application: ACME Inc (TEAMID)" }
 
 [windows]
 binaries = { x86_64 = "zig-out/bin/hello.exe" }
+# signing = { thumbprint = "A1B2C3…", timestamp_url = "http://timestamp.digicert.com" }
+# signing = { sign_command = "trusted-signing-cli -e https://… -a Acct -c Profile -d Hello %1" }
 
 [gui]
 initial_width = 400


### PR DESCRIPTION
This PR exposes `cargo-packager` functionality for signing packages on mac and windows