### PR TITLE
feat(macos): add minimal application menu with About and Quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Runtime
+
+- [macos] Add a minimal application menu with a standard About panel and Quit
+
 ## 0.7.0
 
 ### Runtime

--- a/runtime/macos/Sources/main.swift
+++ b/runtime/macos/Sources/main.swift
@@ -447,13 +447,12 @@ class TrolleyView: NSView, NSTextInputClient {
 // Build a minimal application menu so the packaged app has the expected macOS
 // menu bar: an app menu with the standard "About <App>" panel and Quit. The app
 // name is read from the bundle's Info.plist (CFBundleDisplayName / CFBundleName)
-// so it matches the packaged product name, falling back to a generic label for
+// so it matches the packaged product name, falling back to plain labels for
 // unbundled `trolley run` invocations. The About item uses AppKit's standard
 // panel, which reads the name/version/icon straight from the Info.plist.
 func buildMainMenu() -> NSMenu {
     let appName = (Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String)
         ?? (Bundle.main.infoDictionary?["CFBundleName"] as? String)
-        ?? "App"
 
     let mainMenu = NSMenu()
 
@@ -462,13 +461,13 @@ func buildMainMenu() -> NSMenu {
 
     let appMenu = NSMenu()
     appMenu.addItem(
-        withTitle: "About \(appName)",
+        withTitle: appName.map { "About \($0)" } ?? "About",
         action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)),
         keyEquivalent: ""
     )
     appMenu.addItem(.separator())
     appMenu.addItem(
-        withTitle: "Quit \(appName)",
+        withTitle: appName.map { "Quit \($0)" } ?? "Quit",
         action: #selector(NSApplication.terminate(_:)),
         keyEquivalent: "q"
     )

--- a/runtime/macos/Sources/main.swift
+++ b/runtime/macos/Sources/main.swift
@@ -442,6 +442,42 @@ class TrolleyView: NSView, NSTextInputClient {
 }
 
 // ---------------------------------------------------------------------------
+// Application menu
+// ---------------------------------------------------------------------------
+// Build a minimal application menu so the packaged app has the expected macOS
+// menu bar: an app menu with the standard "About <App>" panel and Quit. The app
+// name is read from the bundle's Info.plist (CFBundleDisplayName / CFBundleName)
+// so it matches the packaged product name, falling back to a generic label for
+// unbundled `trolley run` invocations. The About item uses AppKit's standard
+// panel, which reads the name/version/icon straight from the Info.plist.
+func buildMainMenu() -> NSMenu {
+    let appName = (Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String)
+        ?? (Bundle.main.infoDictionary?["CFBundleName"] as? String)
+        ?? "App"
+
+    let mainMenu = NSMenu()
+
+    let appMenuItem = NSMenuItem()
+    mainMenu.addItem(appMenuItem)
+
+    let appMenu = NSMenu()
+    appMenu.addItem(
+        withTitle: "About \(appName)",
+        action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)),
+        keyEquivalent: ""
+    )
+    appMenu.addItem(.separator())
+    appMenu.addItem(
+        withTitle: "Quit \(appName)",
+        action: #selector(NSApplication.terminate(_:)),
+        keyEquivalent: "q"
+    )
+    appMenuItem.submenu = appMenu
+
+    return mainMenu
+}
+
+// ---------------------------------------------------------------------------
 // AppDelegate
 // ---------------------------------------------------------------------------
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -561,6 +597,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         ghostty_surface_set_size(surface, UInt32(backed.width), UInt32(backed.height))
         ghostty_surface_set_content_scale(surface, Double(window.backingScaleFactor), Double(window.backingScaleFactor))
         ghostty_surface_set_focus(surface, true)
+
+        // -- Install the application menu --
+        NSApp.mainMenu = buildMainMenu()
 
         // -- Show window --
         window.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
## What

Adds a minimal application menu to the macOS runtime so packaged apps get the expected menu bar: an app menu with a standard **About &lt;App&gt;** item and **Quit &lt;App&gt;** (⌘Q).

## Why

`runtime/macos/Sources/main.swift` started `NSApplication` (`.setActivationPolicy(.regular)`, `app.run()`) without ever assigning `NSApp.mainMenu`, so packaged `.app`s had no menu bar at all, hence no About item and no visible way to see the app version from the GUI.

## How

A new `buildMainMenu()` helper builds the menu and is installed in `applicationDidFinishLaunching` just before the window is shown:

- **About &lt;App&gt;** → `orderFrontStandardAboutPanel:` (AppKit's standard panel, which reads name/version/icon straight from the bundle Info.plist that the packager already generates).
- separator
- **Quit &lt;App&gt;** → `terminate:`, key equivalent ⌘Q.

The app name is read from the bundle's `CFBundleDisplayName` / `CFBundleName`, falling back to a generic label so unbundled `trolley run` invocations still work.

No config surface changes; this is generic and applies to every trolley app. CHANGELOG updated under an Unreleased Runtime section.

## Testing

Built the runtime from source (nix dev shell, zig 0.15.2) and packaged a real Kotlin/Native TUI app (`Wire TUI.app`) with `trolley package --formats mac-app`. The bundle launches and shows the application menu; the About item opens the standard panel with the packaged product name and version. Also type-checked the menu builder standalone against AppKit to confirm the item titles/selectors.