### PR TITLE
Fix modifier behavior across Windows, Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Runtime
 
 - [macos] Add a minimal application menu with a standard About panel and Quit
+- [windows, linux] Fix shifted symbols typing the unshifted character (e.g. shift+1 producing "1" instead of "!") in apps using the kitty keyboard protocol
+- [windows, linux] Fix composed input (dead keys, Compose, input methods) reporting wrong key codes to kitty-protocol apps, and no longer drop the keystroke when its text can't be encoded
+- [windows, linux] Fix modified space chords: ctrl/alt+space were dropped entirely and shift+space lost its modifier in apps using the kitty keyboard protocol
 
 ## 0.7.0
 

--- a/runtime/src/platform/linux.zig
+++ b/runtime/src/platform/linux.zig
@@ -176,15 +176,46 @@ fn closeSurfaceCallback(_: ?*anyopaque, _: bool) callconv(.c) void {
 // ---------------------------------------------------------------------------
 // GLFW input callbacks → ghostty
 //
-// Two-phase key input (same pattern as ghostty's deleted GLFW apprt):
-//   1. keyCallback sends the key event with inferred ASCII text.
-//   2. If ghostty ignores it (not consumed), we store the event.
-//   3. charCallback fires with the real Unicode codepoint, updates the
-//      stored event's text, and re-sends it to ghostty.
+// Key input runs one of two protocols:
+//
+// Deferral (primary): keyCallback withholds printable press/repeat events
+// with no ctrl/alt/super; charCallback — invoked by GLFW synchronously
+// right after, in the same OS event — attaches the layout-produced text
+// plus consumed_mods and sends once. This also carries most composition:
+// dead-key/Compose output is delivered inside the finishing keystroke's
+// own event, completing that key's deferral. A deferred press whose char
+// never arrives (e.g. the dead-key press itself) is sent textless by
+// flushDeferred at the next keyCallback or after glfwWaitEvents.
+//
+// Send-then-retry (fallback): everything else is sent immediately (ctrl
+// combos with synthesized text, other keys textless). If ghostty reports
+// the event not consumed, it is parked; a charCallback with no deferred
+// press (async IM commits delivered outside the keystroke's own event)
+// re-sends the parked event with that text.
 // ---------------------------------------------------------------------------
 var g_pending_key_event: ?ghostty.ghostty_input_key_s = null;
 var g_pending_text_buf: [5]u8 = undefined;
 var g_key_text_buf: [5]u8 = undefined;
+
+/// Press/repeat withheld from ghostty until charCallback supplies text.
+/// GLFW invokes the char callback synchronously right after the key
+/// callback, within the same OS event, so a deferred press is completed
+/// (or flushed) before the next key event.
+var g_deferred_key_event: ?ghostty.ghostty_input_key_s = null;
+
+/// Send a deferred press whose charCallback never fired (dead keys,
+/// XIM-filtered presses). A not-consumed event is parked for the retry
+/// path; note the keyCallback-entry call site clears that parking slot
+/// shortly after, so the retry is only reachable from the main-loop flush.
+fn flushDeferred() void {
+    const key_event = g_deferred_key_event orelse return;
+    g_deferred_key_event = null;
+    const surface = g_surface orelse return;
+    const consumed = ghostty.ghostty_surface_key(surface, key_event);
+    if (!consumed) {
+        g_pending_key_event = key_event;
+    }
+}
 
 fn keyCallback(
     _: ?*glfw.GLFWwindow,
@@ -193,6 +224,9 @@ fn keyCallback(
     glfw_action: c_int,
     glfw_mods: c_int,
 ) callconv(.c) void {
+    // Complete any leftover deferred press before handling a new key.
+    flushDeferred();
+
     const surface = g_surface orelse return;
 
     const action: ghostty.ghostty_input_action_e = switch (glfw_action) {
@@ -216,6 +250,12 @@ fn keyCallback(
     // keyval_unicode_unshifted. Required for Kitty keyboard protocol encoding
     // and legacy ctrl+shift+letter handling.
     const unshifted_codepoint: u32 = uc: {
+        // glfwGetKeyName's key filter (input.c) returns NULL for
+        // GLFW_KEY_SPACE even though its unshifted character is
+        // well-defined. Without a codepoint the kitty encoder has no
+        // entry for space, so modified-space chords (ctrl/alt+space)
+        // encode nothing and get dropped.
+        if (glfw_key == glfw.GLFW_KEY_SPACE) break :uc 0x20;
         const key_name = glfw.glfwGetKeyName(glfw_key, scancode);
         if (key_name) |name_ptr| {
             const name: [*:0]const u8 = name_ptr;
@@ -258,6 +298,19 @@ fn keyCallback(
     // Clear any previous pending event.
     g_pending_key_event = null;
 
+    // Defer printable, modifier-free presses until charCallback supplies
+    // the layout text. Sending them textless would let the kitty encoder
+    // consume the press (from unshifted_codepoint alone), so the retry
+    // below never fires and shifted symbols like shift+1 → "!" get lost.
+    if ((action == ghostty.GHOSTTY_ACTION_PRESS or
+        action == ghostty.GHOSTTY_ACTION_REPEAT) and
+        (glfw_mods & (glfw.GLFW_MOD_CONTROL | glfw.GLFW_MOD_ALT | glfw.GLFW_MOD_SUPER)) == 0 and
+        unshifted_codepoint >= 0x20)
+    {
+        g_deferred_key_event = key_event;
+        return;
+    }
+
     const consumed = ghostty.ghostty_surface_key(surface, key_event);
 
     // If ghostty didn't consume this press/repeat, store it so charCallback
@@ -272,6 +325,40 @@ fn keyCallback(
 fn charCallback(_: ?*glfw.GLFWwindow, codepoint: c_uint) callconv(.c) void {
     const surface = g_surface orelse return;
 
+    // Complete a press deferred by keyCallback in this same OS event: the
+    // codepoint here is the layout-produced text for that press.
+    if (g_deferred_key_event) |deferred| {
+        g_deferred_key_event = null;
+        var key_event = deferred;
+
+        // If the codepoint can't be encoded, send the press textless: the
+        // keystroke is still valid, only the text half failed. Unlike
+        // flushDeferred we don't park a not-consumed result — the char
+        // already arrived and was garbage, there is nothing to retry with.
+        text: {
+            const cp: u21 = std.math.cast(u21, codepoint) orelse break :text;
+            const len = std.unicode.utf8Encode(cp, &g_pending_text_buf) catch break :text;
+            if (len < g_pending_text_buf.len) {
+                g_pending_text_buf[len] = 0;
+            }
+
+            key_event.text = &g_pending_text_buf;
+            // Shift/caps were consumed by the translation only if they
+            // actually changed the produced character (shift+1 → "!").
+            // If the char equals the unshifted codepoint (shift+space
+            // → " "), claiming consumption would strip the modifier and
+            // ghostty would send plain text instead of a CSI sequence.
+            // Keep the press-time unshifted_codepoint: overwriting it
+            // with the shifted char would corrupt kitty/CSIu key codes.
+            if (codepoint != key_event.unshifted_codepoint) {
+                key_event.consumed_mods = key_event.mods &
+                    (ghostty.GHOSTTY_MODS_SHIFT | ghostty.GHOSTTY_MODS_CAPS);
+            }
+        }
+        _ = ghostty.ghostty_surface_key(surface, key_event);
+        return;
+    }
+
     // charCallback only matters if we have a pending (ignored) key event.
     var key_event = g_pending_key_event orelse return;
     g_pending_key_event = null;
@@ -285,9 +372,10 @@ fn charCallback(_: ?*glfw.GLFWwindow, codepoint: c_uint) callconv(.c) void {
         g_pending_text_buf[len] = 0;
     }
 
-    // Update the key event with the real text and codepoint.
+    // Update the key event with the real text. Keep the press-time
+    // unshifted_codepoint: overwriting it with the produced char would
+    // corrupt kitty/CSIu key codes.
     key_event.text = &g_pending_text_buf;
-    key_event.unshifted_codepoint = codepoint;
 
     // Re-send the key event to ghostty with the text populated.
     _ = ghostty.ghostty_surface_key(surface, key_event);
@@ -532,6 +620,9 @@ pub fn main() !void {
     while (glfw.glfwWindowShouldClose(window) != glfw.GLFW_TRUE) {
         ghostty.ghostty_app_tick(app);
         glfw.glfwWaitEvents();
+        // Complete any press whose charCallback never fired within the
+        // batch just processed (dead keys, XIM-filtered presses).
+        flushDeferred();
     }
 
     // Exit immediately. Ghostty's Surface.deinit assumes the GL context

--- a/runtime/src/platform/windows.zig
+++ b/runtime/src/platform/windows.zig
@@ -496,7 +496,11 @@ fn closeClipboard() void {
 }
 
 // ---------------------------------------------------------------------------
-// Two-phase key input (same pattern as Linux runtime)
+// Key input: WM_KEYDOWN peeks the WM_CHARs the pump already translated for
+// this keystroke and sends one complete event (text + consumed_mods). The
+// pending/retry state below is the fallback for text the peek cannot see —
+// chars posted outside keydown dispatch (e.g. IME commits) arrive at the
+// WM_CHAR handler and complete a parked not-consumed event.
 // ---------------------------------------------------------------------------
 var g_pending_key_event: ?ghostty.ghostty_input_key_s = null;
 var g_pending_text_buf: [5]u8 = undefined;
@@ -536,6 +540,49 @@ fn extractScancode(lParam: LPARAM) u32 {
     return scan | (extended * 0xe000);
 }
 
+/// Combine UTF-16 code units from WM_CHAR into a codepoint. Codepoints
+/// above U+FFFF arrive as two WM_CHAR messages (high surrogate, then low),
+/// tracked across calls via g_high_surrogate. Returns null while waiting
+/// for the low half or on an orphaned low surrogate.
+fn combineSurrogate(unit: u16) ?u32 {
+    if (unit >= 0xD800 and unit <= 0xDBFF) {
+        // High surrogate — store and wait for the low surrogate
+        g_high_surrogate = unit;
+        return null;
+    }
+
+    if (unit >= 0xDC00 and unit <= 0xDFFF) {
+        // Low surrogate — combine with stored high surrogate
+        if (g_high_surrogate == 0) return null; // orphaned low surrogate
+        const codepoint = (@as(u32, g_high_surrogate) - 0xD800) * 0x400 +
+            (@as(u32, unit) - 0xDC00) + 0x10000;
+        g_high_surrogate = 0;
+        return codepoint;
+    }
+
+    g_high_surrogate = 0;
+    return unit;
+}
+
+/// Drain the WM_CHAR messages already queued for the WM_KEYDOWN currently
+/// being dispatched, returning the last complete codepoint (surrogate pairs
+/// combined) or null if none. This relies on the message pump ordering:
+/// TranslateMessage runs before DispatchMessageW, so by the time windowProc
+/// sees a keydown, that keydown's WM_CHAR(s) are already posted — and posted
+/// messages are retrieved ahead of hardware input, so the peeked chars can
+/// only belong to this keydown.
+fn peekCharForKeydown(hwnd: HWND) ?u32 {
+    var result: ?u32 = null;
+    var m: wam.MSG = undefined;
+    while (wam.PeekMessageW(&m, hwnd, wam.WM_CHAR, wam.WM_CHAR, wam.PM_REMOVE) != 0) {
+        const unit: u16 = @intCast(m.wParam & 0xFFFF);
+        if (combineSurrogate(unit)) |cp| {
+            result = cp;
+        }
+    }
+    return result;
+}
+
 /// Derive the unshifted character for a virtual key code using MapVirtualKeyW.
 /// Returns 0 for non-printable keys. Dead-key bit is masked off.
 fn unshiftedCodepoint(vk_wparam: WPARAM) u32 {
@@ -554,7 +601,7 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
         wam.WM_KEYDOWN, WM_SYSKEYDOWN => {
             const surface = g_surface orelse return wam.DefWindowProcW(hwnd, msg, wParam, lParam);
             const keycode = extractScancode(lParam);
-            const mods = translateMods();
+            var mods = translateMods();
             const action: ghostty.ghostty_input_action_e = if ((@as(u64, @bitCast(lParam)) >> 30) & 1 != 0)
                 ghostty.GHOSTTY_ACTION_REPEAT
             else
@@ -566,11 +613,48 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
             // handling.
             const unshifted_codepoint = unshiftedCodepoint(wParam);
 
-            // When ctrl is held, Windows never sends WM_CHAR, so we must
-            // synthesize the text here. Without text, the legacy encoder's
-            // CSIu path (for ctrl+shift+letter) silently drops the event.
+            // Prefer the layout-produced text from the WM_CHARs that
+            // TranslateMessage already queued for this keydown. Without text
+            // at press time, the kitty encoder consumes the press (from
+            // unshifted_codepoint alone) and the WM_CHAR retry never fires,
+            // dropping shifted symbols like shift+1 → "!".
+            //
+            // Ctrl combinations produce either control-char WM_CHARs
+            // (filtered below) or none at all, so we fall through and
+            // synthesize printable text. Without text, the legacy encoder
+            // drops ctrl+shift+letter events entirely.
             const has_ctrl = (keyState(.CONTROL) & 0x8000) != 0;
+            var consumed_mods: ghostty.ghostty_input_mods_e = ghostty.GHOSTTY_MODS_NONE;
             const text: ?[*]const u8 = txt: {
+                if (peekCharForKeydown(hwnd)) |peeked| {
+                    if (peeked >= 0x20 and peeked != 0x7f) {
+                        const cp: u21 = std.math.cast(u21, peeked) orelse break :txt null;
+                        const len = std.unicode.utf8Encode(cp, &g_key_text_buf) catch break :txt null;
+                        if (len < g_key_text_buf.len) {
+                            g_key_text_buf[len] = 0;
+                        }
+                        // Shift/caps were consumed by the OS translation
+                        // only if they actually changed the produced char
+                        // (shift+1 → "!"). If it equals the unshifted
+                        // codepoint (shift+space → " "), claiming
+                        // consumption would strip the modifier and ghostty
+                        // would send plain text instead of a CSI sequence.
+                        if (peeked != unshifted_codepoint) {
+                            consumed_mods = mods & (ghostty.GHOSTTY_MODS_SHIFT | ghostty.GHOSTTY_MODS_CAPS);
+                        }
+                        // Windows reports AltGr as ctrl+alt. Since the key
+                        // produced printable text, strip both so the raw
+                        // ctrl doesn't suppress the encoders' text paths.
+                        const has_alt = (keyState(.MENU) & 0x8000) != 0;
+                        if (has_ctrl and has_alt) {
+                            mods &= ~@as(ghostty.ghostty_input_mods_e, ghostty.GHOSTTY_MODS_CTRL | ghostty.GHOSTTY_MODS_ALT);
+                        }
+                        break :txt &g_key_text_buf;
+                    }
+                    // Control chars (e.g. ctrl+A's 0x01) are removed from
+                    // the queue and intentionally dropped — the press
+                    // itself encodes them.
+                }
                 if (!has_ctrl) break :txt null;
                 if (unshifted_codepoint < 0x20) break :txt null;
                 var cp: u21 = std.math.cast(u21, unshifted_codepoint) orelse break :txt null;
@@ -588,7 +672,7 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
             const key_event: ghostty.ghostty_input_key_s = .{
                 .action = action,
                 .mods = mods,
-                .consumed_mods = ghostty.GHOSTTY_MODS_NONE,
+                .consumed_mods = consumed_mods,
                 .keycode = keycode,
                 .text = text,
                 .unshifted_codepoint = unshifted_codepoint,
@@ -625,25 +709,7 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
             const surface = g_surface orelse return wam.DefWindowProcW(hwnd, msg, wParam, lParam);
 
             const char_code: u16 = @intCast(wParam & 0xFFFF);
-
-            // Handle UTF-16 surrogate pairs: codepoints above U+FFFF are
-            // delivered as two WM_CHAR messages (high surrogate, then low).
-            if (char_code >= 0xD800 and char_code <= 0xDBFF) {
-                // High surrogate — store and wait for the low surrogate
-                g_high_surrogate = char_code;
-                return 0;
-            }
-
-            var codepoint: u32 = char_code;
-            if (char_code >= 0xDC00 and char_code <= 0xDFFF) {
-                // Low surrogate — combine with stored high surrogate
-                if (g_high_surrogate == 0) return 0; // orphaned low surrogate
-                codepoint = (@as(u32, g_high_surrogate) - 0xD800) * 0x400 +
-                    (@as(u32, char_code) - 0xDC00) + 0x10000;
-                g_high_surrogate = 0;
-            } else {
-                g_high_surrogate = 0;
-            }
+            const codepoint = combineSurrogate(char_code) orelse return 0;
 
             var key_event = g_pending_key_event orelse return 0;
             g_pending_key_event = null;
@@ -655,7 +721,8 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
             }
 
             key_event.text = &g_pending_text_buf;
-            key_event.unshifted_codepoint = codepoint;
+            // Keep the press-time unshifted_codepoint: overwriting it with
+            // the (shifted) WM_CHAR char would corrupt kitty/CSIu key codes.
             _ = ghostty.ghostty_surface_key(surface, key_event);
             return 0;
         },


### PR DESCRIPTION
The Windows and Linux runtimes sent key presses without the text, which were consumed without the fallback later delivering the real characters.

We now mirror Ghostty's own GTK apprt and resolves the layout-produced text *before* the press reaches Ghostty.

Closes #18 