### PR TITLE
Various input fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Runtime
+
+- [macos] Add IME and dead-key support: preedit (marked text) now renders at the cursor and the candidate window is positioned correctly; committed text is delivered whether finished by keyboard or clicked with the mouse
+- [macos] Fix focus tracking so switching away with Cmd+Tab reports focus loss (previously only first-responder changes did)
+- [macos] Fix releasing one of two held modifiers (e.g. one of two Shifts) reporting a press, leaving the modifier stuck for kitty-protocol apps
+- [macos] Fix ctrl+shift+letter encoding nothing, and arrow/function keys typing raw private-use bytes into kitty-protocol apps
+- [windows] Fix dead-key sequences: the pending accent is now held during composition and committed on the finishing key, including dead-then-dead (e.g. two accents) and accents flushed by Enter/Backspace/Escape
+- [linux] Deliver input-method commits from async IMEs (ibus, fcitx over X11) that arrive after the keystroke, including multi-codepoint (CJK) commits
+- [linux] Fix a cancelled Compose/dead-key sequence swallowing its terminating key on setups with no external input method
+
 ## 0.8.0
 
 ### Runtime

--- a/runtime/macos/Sources/main.swift
+++ b/runtime/macos/Sources/main.swift
@@ -27,6 +27,48 @@ func ghosttyMods(_ flags: NSEvent.ModifierFlags) -> ghostty_input_mods_e {
     return ghostty_input_mods_e(mods)
 }
 
+extension NSEvent {
+    /// The text to attach to a key event for ghostty.
+    ///
+    /// Filters what raw `characters` reports for two cases ghostty handles
+    /// itself in its key encoder:
+    ///   - A single control character (ctrl+letter etc.): re-derive the
+    ///     printable char by dropping ctrl from the translation, so the
+    ///     legacy encoder's ctrlSeq/CSIu paths get text to work with.
+    ///     Without this, ctrl+shift+letter encodes nothing at all — the
+    ///     same bug class the linux/windows backends synthesize text for.
+    ///   - A single private-use-area codepoint (arrows, F-keys, Home/End/
+    ///     Delete/PageUp/PageDown report U+F700-F8FF): return nil, or the
+    ///     kitty encoder's plain-text fast path types the raw PUA bytes
+    ///     into kitty-protocol apps instead of encoding a CSI sequence.
+    ///
+    /// Only valid on key events (.keyDown/.keyUp): `characters` traps on
+    /// other event types.
+    var ghosttyCharacters: String? {
+        // If we have no characters associated with this event we do nothing.
+        guard let characters else { return nil }
+
+        if characters.count == 1,
+           let scalar = characters.unicodeScalars.first {
+            // If we have a single control character, then we return the
+            // characters without control pressed. We do this because we
+            // handle control character encoding directly within ghostty's
+            // key encoder.
+            if scalar.value < 0x20 {
+                return self.characters(byApplyingModifiers: modifierFlags.subtracting(.control))
+            }
+
+            // If we have a single value in the PUA, then it's a function
+            // key and we don't want to send PUA ranges down to ghostty.
+            if scalar.value >= 0xF700 && scalar.value <= 0xF8FF {
+                return nil
+            }
+        }
+
+        return characters
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Ghostty runtime callbacks
 // ---------------------------------------------------------------------------
@@ -216,8 +258,35 @@ class TrolleyView: NSView, NSTextInputClient {
     override var wantsUpdateLayer: Bool { true }
 
     // Two-phase key input state
-    private var pendingKeyEvent: ghostty_input_key_s?
     private var keyTextAccumulator: [String]?
+
+    // Marked (preedit) text from the input method. Non-empty means we're
+    // mid-composition: dead-key accent or IME preedit. Composing events are
+    // suppressed by the encoders — kitty passes only plain modifiers, legacy
+    // drops everything — matching the GTK/Win32 preedit contract.
+    private var markedText = NSMutableAttributedString()
+
+    // Whether we last told libghostty we're focused. Fed by two sources —
+    // window key state and first-responder state — last writer wins; the
+    // cache dedupes them so set_focus is only sent on transitions. That's
+    // sound only while this view is the window's sole, permanent first
+    // responder; a second responder would need a real AND of both states.
+    private var focused: Bool = false
+
+    private func focusDidChange(_ focused: Bool) {
+        guard let surface = gSurface else { return }
+        guard self.focused != focused else { return }
+        self.focused = focused
+
+        if !focused {
+            // Focus loss invalidates any in-flight composition, and the
+            // input context is told so the IME's own state doesn't go stale.
+            inputContext?.discardMarkedText()
+            unmarkText()
+        }
+
+        ghostty_surface_set_focus(surface, focused)
+    }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -249,19 +318,41 @@ class TrolleyView: NSView, NSTextInputClient {
     // MARK: - Focus
 
     override func becomeFirstResponder() -> Bool {
-        gSurface.map { ghostty_surface_set_focus($0, true) }
+        focusDidChange(true)
         return true
     }
 
     override func resignFirstResponder() -> Bool {
-        gSurface.map { ghostty_surface_set_focus($0, false) }
+        focusDidChange(false)
         return true
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+
+        // Cmd+tab / app activation changes window key state without touching
+        // first responder, so the responder hooks alone never report focus
+        // loss on app switch. Observe our window's key transitions directly.
+        let center = NotificationCenter.default
+        center.removeObserver(self, name: NSWindow.didBecomeKeyNotification, object: nil)
+        center.removeObserver(self, name: NSWindow.didResignKeyNotification, object: nil)
+        guard let window else { return }
+        center.addObserver(
+            self, selector: #selector(windowKeyStateDidChange(_:)),
+            name: NSWindow.didBecomeKeyNotification, object: window)
+        center.addObserver(
+            self, selector: #selector(windowKeyStateDidChange(_:)),
+            name: NSWindow.didResignKeyNotification, object: window)
+    }
+
+    @objc private func windowKeyStateDidChange(_ notification: Notification) {
+        focusDidChange(window?.isKeyWindow ?? false)
     }
 
     // MARK: - Keyboard input
 
     override func keyDown(with event: NSEvent) {
-        guard let surface = gSurface else { return }
+        guard gSurface != nil else { return }
         let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 
         // Two-phase input: first send raw key, then use interpretKeyEvents
@@ -269,19 +360,35 @@ class TrolleyView: NSView, NSTextInputClient {
         keyTextAccumulator = []
         defer { keyTextAccumulator = nil }
 
+        // Whether marked text existed before this event tells us if the event
+        // cleared a composition without committing (e.g. Escape canceling a
+        // dead key) — that keystroke must be suppressed too.
+        let markedTextBefore = markedText.length > 0
+
         interpretKeyEvents([event])
 
+        // Mirror the (possibly changed) marked text to ghostty's preedit so
+        // the pending accent/preedit renders at the cursor.
+        syncPreedit(clearIfNeeded: markedTextBefore)
+
         if let texts = keyTextAccumulator, !texts.isEmpty {
+            // Committed text is never composing — it's the result of one.
             for text in texts {
                 sendKey(action, event: event, text: text)
             }
         } else {
-            sendKey(action, event: event, text: event.characters)
+            sendKey(
+                action, event: event, text: event.ghosttyCharacters,
+                composing: markedText.length > 0 || markedTextBefore
+            )
         }
     }
 
     override func keyUp(with event: NSEvent) {
-        sendKey(GHOSTTY_ACTION_RELEASE, event: event, text: nil)
+        // The dead key's own release lands mid-composition and is
+        // suppressed like its press.
+        sendKey(GHOSTTY_ACTION_RELEASE, event: event, text: nil,
+                composing: markedText.length > 0)
     }
 
     override func flagsChanged(with event: NSEvent) {
@@ -296,14 +403,46 @@ class TrolleyView: NSView, NSTextInputClient {
         }
 
         let mods = ghosttyMods(event.modifierFlags)
-        let action = (mods.rawValue & mod != 0) ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
+
+        // If the modifier is still active it's a press — unless the event's
+        // own side of the modifier is no longer down, in which case this is
+        // the release of one side while the other side keeps the flag set.
+        // Without this, releasing one of two held shifts sends a PRESS for
+        // the released key and it appears stuck to report-events consumers.
+        var action = GHOSTTY_ACTION_RELEASE
+        if mods.rawValue & mod != 0 {
+            let sidePressed: Bool
+            switch event.keyCode {
+            case 0x38:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICELSHIFTKEYMASK) != 0
+            case 0x3C:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERSHIFTKEYMASK) != 0
+            case 0x3B:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICELCTLKEYMASK) != 0
+            case 0x3E:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERCTLKEYMASK) != 0
+            case 0x3A:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICELALTKEYMASK) != 0
+            case 0x3D:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERALTKEYMASK) != 0
+            case 0x37:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICELCMDKEYMASK) != 0
+            case 0x36:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERCMDKEYMASK) != 0
+            default:
+                sidePressed = true
+            }
+            if sidePressed { action = GHOSTTY_ACTION_PRESS }
+        }
+
         sendKey(action, event: event, text: nil)
     }
 
     private func sendKey(
         _ action: ghostty_input_action_e,
         event: NSEvent,
-        text: String?
+        text: String?,
+        composing: Bool = false
     ) {
         guard let surface = gSurface else { return }
 
@@ -314,7 +453,7 @@ class TrolleyView: NSView, NSTextInputClient {
         key_ev.consumed_mods = ghosttyMods(
             event.modifierFlags.subtracting([.control, .command])
         )
-        key_ev.composing = false
+        key_ev.composing = composing
         key_ev.text = nil
         key_ev.unshifted_codepoint = 0
 
@@ -347,18 +486,74 @@ class TrolleyView: NSView, NSTextInputClient {
         default: return
         }
 
-        keyTextAccumulator?.append(chars)
+        // If insertText is called, our preedit is over.
+        unmarkText()
+
+        // Inside a keyDown the text is accumulated and sent with the key
+        // event; outside one (e.g. IME candidate clicked with the mouse,
+        // Character Viewer) there is no key event to attach it to.
+        if keyTextAccumulator != nil {
+            keyTextAccumulator?.append(chars)
+            return
+        }
+
+        guard let surface = gSurface else { return }
+        chars.withCString { ptr in
+            ghostty_surface_text(surface, ptr, UInt(chars.utf8.count))
+        }
     }
 
-    func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {}
-    func unmarkText() {}
-    func selectedRange() -> NSRange { NSRange(location: NSNotFound, length: 0) }
-    func markedRange() -> NSRange { NSRange(location: NSNotFound, length: 0) }
-    func hasMarkedText() -> Bool { false }
+    func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
+        switch string {
+        case let v as NSAttributedString: markedText = NSMutableAttributedString(attributedString: v)
+        case let v as String: markedText = NSMutableAttributedString(string: v)
+        default: return
+        }
+
+        // Outside a keyDown (e.g. keyboard layout switched mid-composition)
+        // nobody else will sync the preedit, so do it here.
+        if keyTextAccumulator == nil { syncPreedit() }
+    }
+
+    func unmarkText() {
+        guard markedText.length > 0 else { return }
+        markedText.mutableString.setString("")
+        syncPreedit()
+    }
+
+    func selectedRange() -> NSRange { NSRange() }
+    func markedRange() -> NSRange { markedText.length > 0 ? NSRange(0...(markedText.length - 1)) : NSRange() }
+    func hasMarkedText() -> Bool { markedText.length > 0 }
     func attributedSubstring(forProposedRange range: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? { nil }
     func validAttributesForMarkedText() -> [NSAttributedString.Key] { [] }
-    func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect { .zero }
+
+    func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {
+        guard let surface = gSurface, let window = self.window else { return .zero }
+
+        // Ghostty tells us where the IME candidate window should render,
+        // in top-left-origin view points; AppKit wants bottom-left screen coords.
+        var x: Double = 0, y: Double = 0, width: Double = 0, height: Double = 0
+        ghostty_surface_ime_point(surface, &x, &y, &width, &height)
+
+        let viewRect = NSRect(x: x, y: frame.size.height - y, width: width, height: height)
+        return window.convertToScreen(convert(viewRect, to: nil))
+    }
+
     func characterIndex(for point: NSPoint) -> Int { 0 }
+
+    /// Mirror markedText to libghostty's preedit so the pending
+    /// accent/preedit renders at the cursor.
+    private func syncPreedit(clearIfNeeded: Bool = true) {
+        guard let surface = gSurface else { return }
+        if markedText.length > 0 {
+            let str = markedText.string
+            str.withCString { ptr in
+                ghostty_surface_preedit(surface, ptr, UInt(str.utf8.count))
+            }
+        } else if clearIfNeeded {
+            ghostty_surface_preedit(surface, nil, 0)
+        }
+    }
 
     override func doCommand(by selector: Selector) {
         // Prevents NSBeep for unhandled key equivalents

--- a/runtime/src/platform/linux.zig
+++ b/runtime/src/platform/linux.zig
@@ -184,8 +184,9 @@ fn closeSurfaceCallback(_: ?*anyopaque, _: bool) callconv(.c) void {
 // plus consumed_mods and sends once. This also carries most composition:
 // dead-key/Compose output is delivered inside the finishing keystroke's
 // own event, completing that key's deferral. A deferred press whose char
-// never arrives (e.g. the dead-key press itself) is sent textless by
-// flushDeferred at the next keyCallback or after glfwWaitEvents.
+// never arrives (e.g. the dead-key press itself) is sent textless — and
+// marked composing, so the encoders suppress it — by flushDeferred at the
+// next keyCallback or after glfwWaitEvents, then parked for the retry.
 //
 // Send-then-retry (fallback): everything else is sent immediately (ctrl
 // combos with synthesized text, other keys textless). If ghostty reports
@@ -203,18 +204,28 @@ var g_key_text_buf: [5]u8 = undefined;
 /// (or flushed) before the next key event.
 var g_deferred_key_event: ?ghostty.ghostty_input_key_s = null;
 
-/// Send a deferred press whose charCallback never fired (dead keys,
-/// XIM-filtered presses). A not-consumed event is parked for the retry
-/// path; note the keyCallback-entry call site clears that parking slot
-/// shortly after, so the retry is only reachable from the main-loop flush.
+/// True while the input pipeline holds composition state for a swallowed
+/// printable press (dead key, Compose middle key, IM preedit). Composing
+/// events are suppressed by the encoders — kitty passes only plain
+/// modifiers, legacy drops everything — matching the GTK preedit contract.
+var g_composing: bool = false;
+
+/// Send a deferred press whose charCallback never fired. The deferral
+/// predicate admits only printable, modifier-free presses, so a missing
+/// char means the input pipeline swallowed it: dead key, Compose middle
+/// key, or an IM-filtered press — all composition, all suppressed via
+/// composing=true. The event is parked unconditionally for the retry
+/// path: async IMs (ibus/fcitx over X11) deliver the commit char in a
+/// later batch, and a suppressed composing event's consumed result says
+/// nothing about whether that retry will be needed.
 fn flushDeferred() void {
-    const key_event = g_deferred_key_event orelse return;
+    var key_event = g_deferred_key_event orelse return;
     g_deferred_key_event = null;
     const surface = g_surface orelse return;
-    const consumed = ghostty.ghostty_surface_key(surface, key_event);
-    if (!consumed) {
-        g_pending_key_event = key_event;
-    }
+    g_composing = true;
+    key_event.composing = true;
+    _ = ghostty.ghostty_surface_key(surface, key_event);
+    g_pending_key_event = key_event;
 }
 
 fn keyCallback(
@@ -292,11 +303,19 @@ fn keyCallback(
         .keycode = keycode,
         .text = text,
         .unshifted_codepoint = unshifted_codepoint,
-        .composing = false,
+        // A release built right after flushDeferred marked a composition
+        // (most commonly the flushed key's own release) is suppressed with
+        // it. Presses always start out non-composing here: the deferral or
+        // flushDeferred decides otherwise.
+        .composing = if (action == ghostty.GHOSTTY_ACTION_RELEASE) g_composing else false,
     };
 
-    // Clear any previous pending event.
-    g_pending_key_event = null;
+    // Clear any previous pending event — press/repeat only: a release
+    // (most commonly the flushed key's own) must not destroy a parked
+    // retry before an async IM commit arrives.
+    if (action != ghostty.GHOSTTY_ACTION_RELEASE) {
+        g_pending_key_event = null;
+    }
 
     // Defer printable, modifier-free presses until charCallback supplies
     // the layout text. Sending them textless would let the kitty encoder
@@ -310,6 +329,11 @@ fn keyCallback(
         g_deferred_key_event = key_event;
         return;
     }
+
+    // Keys reaching the immediate path either resolve or are unaffected by
+    // composition; a stuck false positive must never eat Enter or Escape,
+    // so the flag's blast radius is one flushed press plus one release.
+    g_composing = false;
 
     const consumed = ghostty.ghostty_surface_key(surface, key_event);
 
@@ -329,6 +353,9 @@ fn charCallback(_: ?*glfw.GLFWwindow, codepoint: c_uint) callconv(.c) void {
     // codepoint here is the layout-produced text for that press.
     if (g_deferred_key_event) |deferred| {
         g_deferred_key_event = null;
+        // A synchronous char is the commit (or a plain keystroke): any
+        // pending composition just resolved.
+        g_composing = false;
         var key_event = deferred;
 
         // If the codepoint can't be encoded, send the press textless: the
@@ -362,6 +389,13 @@ fn charCallback(_: ?*glfw.GLFWwindow, codepoint: c_uint) callconv(.c) void {
     // charCallback only matters if we have a pending (ignored) key event.
     var key_event = g_pending_key_event orelse return;
     g_pending_key_event = null;
+
+    // The parked event was sent as a suppressed composing press; this late
+    // char is the commit (async ibus/fcitx delivers it in a batch after the
+    // keystroke's own). Re-send as a normal press so the text isn't
+    // suppressed in turn.
+    g_composing = false;
+    key_event.composing = false;
 
     // Encode the codepoint as UTF-8 into our persistent buffer.
     const cp: u21 = std.math.cast(u21, codepoint) orelse return;
@@ -425,6 +459,8 @@ fn framebufferSizeCallback(_: ?*glfw.GLFWwindow, width: c_int, height: c_int) ca
 }
 
 fn focusCallback(_: ?*glfw.GLFWwindow, focused: c_int) callconv(.c) void {
+    // Focus loss invalidates any in-flight composition.
+    if (focused != glfw.GLFW_TRUE) g_composing = false;
     const surface = g_surface orelse return;
     ghostty.ghostty_surface_set_focus(surface, focused == glfw.GLFW_TRUE);
 }

--- a/runtime/src/platform/linux.zig
+++ b/runtime/src/platform/linux.zig
@@ -176,23 +176,34 @@ fn closeSurfaceCallback(_: ?*anyopaque, _: bool) callconv(.c) void {
 // ---------------------------------------------------------------------------
 // GLFW input callbacks → ghostty
 //
-// Key input runs one of two protocols:
+// Key input delivers text along one of three paths:
 //
-// Deferral (primary): keyCallback withholds printable press/repeat events
-// with no ctrl/alt/super; charCallback — invoked by GLFW synchronously
-// right after, in the same OS event — attaches the layout-produced text
-// plus consumed_mods and sends once. This also carries most composition:
-// dead-key/Compose output is delivered inside the finishing keystroke's
-// own event, completing that key's deferral. A deferred press whose char
-// never arrives (e.g. the dead-key press itself) is sent textless — and
-// marked composing, so the encoders suppress it — by flushDeferred at the
-// next keyCallback or after glfwWaitEvents, then parked for the retry.
+// Deferral-attach (plain typing): keyCallback withholds printable
+// press/repeat events with no ctrl/alt/super; charCallback — invoked by
+// GLFW synchronously right after, in the same OS event — attaches the
+// layout-produced text plus consumed_mods and sends once. A deferred
+// press whose char never arrives (dead key, Compose middle key, an
+// IM-filtered press) is sent textless — and marked composing, so the
+// encoders suppress it — by flushDeferred at the next keyCallback or
+// after glfwWaitEvents, then parked. Under g_sync_compose (no external
+// IM, chars synchronous) a flush that lands while already composing is
+// instead delivered non-composing as the compose terminator (repeats of
+// the composing key excepted).
 //
-// Send-then-retry (fallback): everything else is sent immediately (ctrl
+// Standalone commit (composing text, sync or async): a char arriving
+// while composing — a dead-key finish, or an ibus/fcitx commit delivered
+// in a later batch — is sent as a fabricated keycode-less press carrying
+// only the text, and the suppressed press it finishes is swallowed. This
+// is ghostty GTK's imCommit contract: committed text rides a key event
+// only for plain typing, never for a composition commit, so no keycode
+// can ever be misattributed. Remaining codepoints of a multi-codepoint
+// commit (CJK) follow via g_commit_burst. The swallowed press's release
+// still encodes under kitty report_events — GTK has the same asymmetry.
+//
+// Retry-attach (fallback): everything else is sent immediately (ctrl
 // combos with synthesized text, other keys textless). If ghostty reports
-// the event not consumed, it is parked; a charCallback with no deferred
-// press (async IM commits delivered outside the keystroke's own event)
-// re-sends the parked event with that text.
+// the event not consumed, it is parked; a non-composing charCallback with
+// no deferred press re-sends the parked event with that text.
 // ---------------------------------------------------------------------------
 var g_pending_key_event: ?ghostty.ghostty_input_key_s = null;
 var g_pending_text_buf: [5]u8 = undefined;
@@ -208,7 +219,76 @@ var g_deferred_key_event: ?ghostty.ghostty_input_key_s = null;
 /// printable press (dead key, Compose middle key, IM preedit). Composing
 /// events are suppressed by the encoders — kitty passes only plain
 /// modifiers, legacy drops everything — matching the GTK preedit contract.
+/// g_composing_keycode records the keycode of the flush that set it.
 var g_composing: bool = false;
+
+/// True after a composition commit was delivered standalone; admits the
+/// remaining codepoints of a multi-codepoint commit (CJK) to the same
+/// path. Cleared on the next key press/repeat and on focus loss.
+var g_commit_burst: bool = false;
+/// Dedicated buffer (not g_pending_text_buf) so a burst send can never
+/// clobber text belonging to a still-parked event.
+var g_commit_text_buf: [5]u8 = undefined;
+
+/// True when GLFW's compose pipeline is synchronous — native Wayland
+/// (GLFW has no IM integration there; chars come from in-process
+/// xkb-compose) or X11 with no external XIM configured. Under this gate
+/// a deferred press whose char never arrived in its batch will NEVER
+/// receive one later, so a flush-while-already-composing is a compose
+/// terminator, not an in-flight IM keystroke. Under an external IM
+/// (XMODIFIERS=@im=fcitx etc.) chars are async and every printable
+/// flushes textless — the same condition would fire on fast typing and
+/// double-deliver once the async char lands, so the gate MUST stay off.
+/// Computed once after glfwInit, before loadBundledEnvironment mutates
+/// the environment libX11 read.
+var g_sync_compose: bool = false;
+
+/// Keycode of the press whose flush most recently set g_composing;
+/// lets a held dead key's repeats (same keycode, REPEAT action) stay
+/// suppressed instead of leaking through the terminator rule.
+var g_composing_keycode: u32 = 0;
+
+/// Dedicated buffer for terminator-synthesized text (mirrors the
+/// g_commit_text_buf precedent: never alias a buffer a parked event
+/// might still point at).
+var g_terminator_text_buf: [5]u8 = undefined;
+
+/// XIM discovery mirror: libX11 reaches an external server only via
+/// XMODIFIERS "@im=<name>"; empty, "none" and "local" mean the built-in
+/// input method. Returns false on non-X11 platforms.
+fn detectExternalXim() bool {
+    if (glfw.glfwGetPlatform() != glfw.GLFW_PLATFORM_X11) return false;
+    const xmods = std.posix.getenv("XMODIFIERS") orelse return false;
+    const idx = std.mem.indexOf(u8, xmods, "@im=") orelse return false;
+    const rest = xmods[idx + "@im=".len ..];
+    const end = std.mem.indexOfScalar(u8, rest, '@') orelse rest.len;
+    const name = rest[0..end];
+    if (name.len == 0) return false;
+    if (std.mem.eql(u8, name, "none")) return false;
+    if (std.mem.eql(u8, name, "local")) return false;
+    return true;
+}
+
+/// Deliver committed IM text standalone, mirroring ghostty GTK's imCommit
+/// composing/out-of-keyevent path: a press with an unmapped keycode
+/// (-> .unidentified), no mods, no unshifted codepoint, composing=false.
+/// Both encoders emit the utf8 raw (key_encode.zig kitty fallback /
+/// legacy tail), in every kitty flag combination.
+fn sendCommitText(codepoint: c_uint) void {
+    const surface = g_surface orelse return;
+    const cp: u21 = std.math.cast(u21, codepoint) orelse return;
+    const len = std.unicode.utf8Encode(cp, &g_commit_text_buf) catch return;
+    if (len < g_commit_text_buf.len) g_commit_text_buf[len] = 0;
+    _ = ghostty.ghostty_surface_key(surface, .{
+        .action = ghostty.GHOSTTY_ACTION_PRESS,
+        .mods = ghostty.GHOSTTY_MODS_NONE,
+        .consumed_mods = ghostty.GHOSTTY_MODS_NONE,
+        .keycode = 0, // matches no real key -> input.Key.unidentified
+        .text = &g_commit_text_buf,
+        .unshifted_codepoint = 0,
+        .composing = false,
+    });
+}
 
 /// Send a deferred press whose charCallback never fired. The deferral
 /// predicate admits only printable, modifier-free presses, so a missing
@@ -217,15 +297,85 @@ var g_composing: bool = false;
 /// composing=true. The event is parked unconditionally for the retry
 /// path: async IMs (ibus/fcitx over X11) deliver the commit char in a
 /// later batch, and a suppressed composing event's consumed result says
-/// nothing about whether that retry will be needed.
+/// nothing about whether that retry will be needed. Exception: under
+/// g_sync_compose a flush while already composing takes the terminator
+/// branch — delivered with text, not parked.
 fn flushDeferred() void {
     var key_event = g_deferred_key_event orelse return;
     g_deferred_key_event = null;
     const surface = g_surface orelse return;
+
+    // Sync-compose terminator (g_sync_compose): a textless flush while
+    // ALREADY composing means GLFW's compose layer swallowed this key's
+    // char — a cancelled sequence's terminating key. Its char will never
+    // arrive (chars are synchronous under the gate), so suppressing it
+    // as composing would eat the keystroke outright; deliver it
+    // non-composing with its own codepoint instead (restores master's
+    // bare-q; the swallowed accent is unrecoverable, GLFW discards it).
+    // Accepted cost: middle keys of 3+-key Compose sequences leak.
+    if (g_sync_compose and g_composing) {
+        // Held-dead-key repeats re-flush textless while composing but
+        // terminate nothing: same keycode that started the composition,
+        // REPEAT action. Keep today's suppression for those.
+        if (key_event.action == ghostty.GHOSTTY_ACTION_REPEAT and
+            key_event.keycode == g_composing_keycode)
+        {
+            key_event.composing = true;
+            _ = ghostty.ghostty_surface_key(surface, key_event);
+            g_pending_key_event = key_event;
+            return;
+        }
+
+        g_composing = false;
+        key_event.composing = false;
+        // Synthesize the key's own text (same shape as the ctrl-combo
+        // synthesis in keyCallback); on encode failure send textless —
+        // kitty still CSIu-encodes it from unshifted_codepoint (the
+        // master behavior this branch restores).
+        text: {
+            var cp: u21 = std.math.cast(u21, key_event.unshifted_codepoint) orelse break :text;
+            const shifted = (key_event.mods & ghostty.GHOSTTY_MODS_SHIFT) != 0;
+            if (shifted and cp >= 'a' and cp <= 'z') cp = cp - 'a' + 'A';
+            const len = std.unicode.utf8Encode(cp, &g_terminator_text_buf) catch break :text;
+            if (len < g_terminator_text_buf.len) g_terminator_text_buf[len] = 0;
+            key_event.text = &g_terminator_text_buf;
+            if (cp != key_event.unshifted_codepoint) {
+                key_event.consumed_mods = key_event.mods &
+                    (ghostty.GHOSTTY_MODS_SHIFT | ghostty.GHOSTTY_MODS_CAPS);
+            }
+        }
+        _ = ghostty.ghostty_surface_key(surface, key_event);
+        // Deliberately NOT parked: it was delivered with text; parking
+        // would let a stray char double-deliver it via rule 3.
+        return;
+    }
+
     g_composing = true;
+    g_composing_keycode = key_event.keycode;
     key_event.composing = true;
     _ = ghostty.ghostty_surface_key(surface, key_event);
     g_pending_key_event = key_event;
+}
+
+/// A bare modifier keysym (shift/ctrl/alt/super/caps). Its press reaches
+/// the immediate path but is transparent to composition: pressing Shift
+/// to type a capital while a dead key is pending must not cancel the
+/// pending compose (unlike Enter/Escape/a letter, which legitimately
+/// terminate it). Used to gate the composing-clear at the immediate path.
+fn isModifierKey(glfw_key: c_int) bool {
+    return switch (glfw_key) {
+        glfw.GLFW_KEY_LEFT_SHIFT,
+        glfw.GLFW_KEY_RIGHT_SHIFT,
+        glfw.GLFW_KEY_LEFT_CONTROL,
+        glfw.GLFW_KEY_RIGHT_CONTROL,
+        glfw.GLFW_KEY_LEFT_ALT,
+        glfw.GLFW_KEY_RIGHT_ALT,
+        glfw.GLFW_KEY_LEFT_SUPER,
+        glfw.GLFW_KEY_RIGHT_SUPER,
+        glfw.GLFW_KEY_CAPS_LOCK,
+        => true,
+        else => false,
+    };
 }
 
 fn keyCallback(
@@ -310,11 +460,13 @@ fn keyCallback(
         .composing = if (action == ghostty.GHOSTTY_ACTION_RELEASE) g_composing else false,
     };
 
-    // Clear any previous pending event — press/repeat only: a release
-    // (most commonly the flushed key's own) must not destroy a parked
-    // retry before an async IM commit arrives.
+    // Clear any previous pending event and commit burst — press/repeat
+    // only: a release (most commonly the flushed key's own) must not
+    // destroy a parked retry, and raw releases can interleave the chars
+    // of a multi-codepoint commit burst.
     if (action != ghostty.GHOSTTY_ACTION_RELEASE) {
         g_pending_key_event = null;
+        g_commit_burst = false;
     }
 
     // Defer printable, modifier-free presses until charCallback supplies
@@ -330,10 +482,22 @@ fn keyCallback(
         return;
     }
 
-    // Keys reaching the immediate path either resolve or are unaffected by
-    // composition; a stuck false positive must never eat Enter or Escape,
-    // so the flag's blast radius is one flushed press plus one release.
-    g_composing = false;
+    // Press/repeat only: keys reaching the immediate path either resolve
+    // or are unaffected by composition, so a press/repeat retires the
+    // composing flag — a stuck false positive still can't eat Enter or
+    // Escape. Releases must NOT clear it: after a flushed dead key or
+    // IM finisher, the async commit chars race the finisher's own
+    // release over the input-method round-trip, and a release-time
+    // clear would drop the commit at charCallback rule 5. It would also
+    // let a dead key's own release (arriving between the flush and the
+    // finishing char) demote the finish from the standalone rule-1 send
+    // to a keycode-attached rule-2 send. Bare modifier presses are also
+    // exempt: pressing Shift to reach a capital while a dead key is
+    // pending (e.g. `'` then Shift+Q) must keep the composition alive so
+    // the terminator can deliver Q — clearing here would strand the
+    // still-deferred letter on the suppressing normal path.
+    if (action != ghostty.GHOSTTY_ACTION_RELEASE and !isModifierKey(glfw_key))
+        g_composing = false;
 
     const consumed = ghostty.ghostty_surface_key(surface, key_event);
 
@@ -349,13 +513,26 @@ fn keyCallback(
 fn charCallback(_: ?*glfw.GLFWwindow, codepoint: c_uint) callconv(.c) void {
     const surface = g_surface orelse return;
 
-    // Complete a press deferred by keyCallback in this same OS event: the
-    // codepoint here is the layout-produced text for that press.
+    // Rule 1 — composition commit. A char arriving while composing is the
+    // commit of the suppressed press (sync dead-key finish, or async
+    // ibus/fcitx commit from a later batch). GTK contract: deliver it
+    // standalone, never attached to a keycode; the finishing press (open
+    // deferral) is swallowed like GTK swallows it (keyEvent early return),
+    // and the parked suppressed press is retired — its commit has landed.
+    if (g_composing) {
+        g_composing = false;
+        g_deferred_key_event = null;
+        g_pending_key_event = null;
+        g_commit_burst = true;
+        sendCommitText(codepoint);
+        return;
+    }
+
+    // Rule 2 — plain typing: complete a press deferred by keyCallback in
+    // this same OS event; the codepoint here is the layout-produced text
+    // for that press.
     if (g_deferred_key_event) |deferred| {
         g_deferred_key_event = null;
-        // A synchronous char is the commit (or a plain keystroke): any
-        // pending composition just resolved.
-        g_composing = false;
         var key_event = deferred;
 
         // If the codepoint can't be encoded, send the press textless: the
@@ -386,33 +563,42 @@ fn charCallback(_: ?*glfw.GLFWwindow, codepoint: c_uint) callconv(.c) void {
         return;
     }
 
-    // charCallback only matters if we have a pending (ignored) key event.
-    var key_event = g_pending_key_event orelse return;
-    g_pending_key_event = null;
+    // Rule 3 — non-composing retry: a parked immediate-path press (e.g.
+    // super+letter sent textless and not consumed) gets its synchronous
+    // char attached. (Not alt/ctrl+letter: GLFW's `plain` gating skips
+    // charCallback entirely when ctrl or alt is held.)
+    if (g_pending_key_event) |pending| {
+        g_pending_key_event = null;
+        var key_event = pending;
 
-    // The parked event was sent as a suppressed composing press; this late
-    // char is the commit (async ibus/fcitx delivers it in a batch after the
-    // keystroke's own). Re-send as a normal press so the text isn't
-    // suppressed in turn.
-    g_composing = false;
-    key_event.composing = false;
+        // Encode the codepoint as UTF-8 into our persistent buffer.
+        const cp: u21 = std.math.cast(u21, codepoint) orelse return;
+        const len = std.unicode.utf8Encode(cp, &g_pending_text_buf) catch return;
 
-    // Encode the codepoint as UTF-8 into our persistent buffer.
-    const cp: u21 = std.math.cast(u21, codepoint) orelse return;
-    const len = std.unicode.utf8Encode(cp, &g_pending_text_buf) catch return;
+        // Null-terminate for the C API (ghostty expects a C string).
+        if (len < g_pending_text_buf.len) {
+            g_pending_text_buf[len] = 0;
+        }
 
-    // Null-terminate for the C API (ghostty expects a C string).
-    if (len < g_pending_text_buf.len) {
-        g_pending_text_buf[len] = 0;
+        // Update the key event with the real text. Keep the press-time
+        // unshifted_codepoint: overwriting it with the produced char would
+        // corrupt kitty/CSIu key codes.
+        key_event.text = &g_pending_text_buf;
+
+        // Re-send the key event to ghostty with the text populated.
+        _ = ghostty.ghostty_surface_key(surface, key_event);
+        return;
     }
 
-    // Update the key event with the real text. Keep the press-time
-    // unshifted_codepoint: overwriting it with the produced char would
-    // corrupt kitty/CSIu key codes.
-    key_event.text = &g_pending_text_buf;
+    // Rule 4 — remainder of a multi-codepoint commit, or text injected
+    // with no keystroke at all since the commit began.
+    if (g_commit_burst) {
+        sendCommitText(codepoint);
+        return;
+    }
 
-    // Re-send the key event to ghostty with the text populated.
-    _ = ghostty.ghostty_surface_key(surface, key_event);
+    // Rule 5 — no context (e.g. char whose press was consumed as a
+    // keybind): drop.
 }
 
 fn mouseButtonCallback(
@@ -459,8 +645,19 @@ fn framebufferSizeCallback(_: ?*glfw.GLFWwindow, width: c_int, height: c_int) ca
 }
 
 fn focusCallback(_: ?*glfw.GLFWwindow, focused: c_int) callconv(.c) void {
-    // Focus loss invalidates any in-flight composition.
-    if (focused != glfw.GLFW_TRUE) g_composing = false;
+    // Focus loss invalidates any in-flight composition: a commit arriving
+    // after refocus must not attach to a pre-blur press, and a stale burst
+    // must not leak text past it. The open deferral is left alone — it
+    // belongs to a keystroke in the current batch and the main-loop
+    // flushDeferred handles it. Note that flush can then re-park the
+    // pre-blur press and re-set g_composing after this clear; the
+    // no-stale-attach guarantee still holds because composing routes any
+    // late char to the standalone-commit rule, never the parked retry.
+    if (focused != glfw.GLFW_TRUE) {
+        g_composing = false;
+        g_pending_key_event = null;
+        g_commit_burst = false;
+    }
     const surface = g_surface orelse return;
     ghostty.ghostty_surface_set_focus(surface, focused == glfw.GLFW_TRUE);
 }
@@ -521,6 +718,11 @@ pub fn main() !void {
         return error.GlfwInitFailed;
     }
     defer glfw.glfwTerminate();
+
+    // After glfwInit (platform decided; the XIM connection, if any, is
+    // made from the current environment) and before loadBundledEnvironment
+    // below can mutate that environment.
+    g_sync_compose = !detectExternalXim();
 
     // Request OpenGL 4.3 core profile (ghostty minimum)
     glfw.glfwWindowHint(glfw.GLFW_CONTEXT_VERSION_MAJOR, 4);

--- a/runtime/src/platform/windows.zig
+++ b/runtime/src/platform/windows.zig
@@ -504,7 +504,7 @@ fn closeClipboard() void {
 // ---------------------------------------------------------------------------
 var g_pending_key_event: ?ghostty.ghostty_input_key_s = null;
 var g_pending_text_buf: [5]u8 = undefined;
-var g_key_text_buf: [5]u8 = undefined;
+var g_key_text_buf: [128]u8 = undefined;
 var g_high_surrogate: u16 = 0;
 
 /// True while the kernel holds a pending dead-key accent (WM_DEADCHAR seen,
@@ -570,23 +570,64 @@ fn combineSurrogate(unit: u16) ?u32 {
     return unit;
 }
 
+const CharBurst = struct {
+    /// Complete codepoints drained from the queue (printable or control).
+    seen: usize = 0,
+    /// Bytes of printable UTF-8 accumulated in g_key_text_buf
+    /// (NUL-terminated at [len]); 0 when the burst had no printables.
+    len: usize = 0,
+    /// Last printable codepoint appended. In a flushed-dead-key burst
+    /// ("´q") earlier codepoints are the flushed accent(s); the last one
+    /// is the char produced by this keystroke's own translation. Stale
+    /// (the accent) when trailing_control is set — but then the text is
+    /// never attached, so it goes unread.
+    last_printable: u32 = 0,
+    /// True when the burst's final complete codepoint was a control
+    /// char: the keystroke's own translation was a control (Enter's
+    /// 0x0D, Backspace's 0x08 flushing a dead-key accent), so any
+    /// accumulated printables are a flushed accent that must not ride
+    /// this event — the encoders' enter/backspace text carve-outs
+    /// would replace the key's function with the accent text.
+    trailing_control: bool = false,
+};
+
 /// Drain the WM_CHAR messages already queued for the WM_KEYDOWN currently
-/// being dispatched, returning the last complete codepoint (surrogate pairs
-/// combined) or null if none. This relies on the message pump ordering:
+/// being dispatched, accumulating the printable codepoints (surrogate pairs
+/// combined) as UTF-8 in g_key_text_buf. A keystroke can queue more than
+/// one: a failed dead-key composition flushes the pending accent alongside
+/// the key's own char. This relies on the message pump ordering:
 /// TranslateMessage runs before DispatchMessageW, so by the time windowProc
 /// sees a keydown, that keydown's WM_CHAR(s) are already posted — and posted
 /// messages are retrieved ahead of hardware input, so the peeked chars can
 /// only belong to this keydown.
-fn peekCharForKeydown(hwnd: HWND) ?u32 {
-    var result: ?u32 = null;
+fn peekCharForKeydown(hwnd: HWND) CharBurst {
+    var burst: CharBurst = .{};
     var m: wam.MSG = undefined;
     while (wam.PeekMessageW(&m, hwnd, wam.WM_CHAR, wam.WM_CHAR, wam.PM_REMOVE) != 0) {
         const unit: u16 = @intCast(m.wParam & 0xFFFF);
-        if (combineSurrogate(unit)) |cp| {
-            result = cp;
+        const cp32 = combineSurrogate(unit) orelse continue;
+        burst.seen += 1;
+        // Control chars (ctrl+A's 0x01, Escape's 0x1B flushing dead
+        // state) are drained but never appended: the press itself
+        // encodes them, and a single control codepoint would force the
+        // kitty encoder off its plain-text path for the whole string.
+        // A control in final position additionally marks the burst so
+        // earlier printables don't ride the event (see trailing_control).
+        if (cp32 < 0x20 or cp32 == 0x7f) {
+            burst.trailing_control = true;
+            continue;
         }
+        const cp: u21 = std.math.cast(u21, cp32) orelse continue;
+        // Reserve one byte for the NUL terminator; drop codepoints that
+        // no longer fit (whole codepoints only — never partial UTF-8).
+        if (burst.len + 4 >= g_key_text_buf.len) continue;
+        const n = std.unicode.utf8Encode(cp, g_key_text_buf[burst.len..]) catch continue;
+        burst.len += n;
+        burst.last_printable = cp32;
+        burst.trailing_control = false;
     }
-    return result;
+    if (burst.len > 0) g_key_text_buf[burst.len] = 0;
+    return burst;
 }
 
 /// Drain the WM_DEADCHAR/WM_SYSDEADCHAR messages queued for the WM_KEYDOWN
@@ -607,6 +648,25 @@ fn peekDeadCharForKeydown(hwnd: HWND) bool {
         dead = true;
     }
     return dead;
+}
+
+/// Deliver already-encoded UTF-8 standalone, mirroring ghostty GTK's
+/// imCommit composing path (and linux.zig's sendCommitText): a press
+/// with keycode 0 (-> input.Key.unidentified), no mods, no unshifted
+/// codepoint, composing=false. Both encoders emit the utf8 raw in every
+/// kitty flag combination. Mods are deliberately NOT translateMods():
+/// an AltGr-committed accent must not carry ctrl+alt, which would push
+/// the kitty encoder off its plain-text path.
+fn sendStandaloneText(surface: ghostty.ghostty_surface_t, text: [*]const u8) void {
+    _ = ghostty.ghostty_surface_key(surface, .{
+        .action = ghostty.GHOSTTY_ACTION_PRESS,
+        .mods = ghostty.GHOSTTY_MODS_NONE,
+        .consumed_mods = ghostty.GHOSTTY_MODS_NONE,
+        .keycode = 0,
+        .text = text,
+        .unshifted_codepoint = 0,
+        .composing = false,
+    });
 }
 
 /// Derive the unshifted character for a virtual key code using MapVirtualKeyW.
@@ -646,7 +706,7 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
             // dropping shifted symbols like shift+1 → "!".
             //
             // Ctrl combinations produce either control-char WM_CHARs
-            // (filtered below) or none at all, so we fall through and
+            // (dropped by the peek) or none at all, so we fall through and
             // synthesize printable text. Without text, the legacy encoder
             // drops ctrl+shift+letter events entirely.
             // Drain this keydown's translation output up front. A deadchar
@@ -654,58 +714,72 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
             // second dead key restarting one — if a char arrived alongside,
             // the deadchar wins): the kernel now holds the accent, so the
             // event must be marked composing or the encoders leak a
-            // spurious keystroke. A char resolves any pending composition:
-            // printable is the commit (text attached below); a control char
-            // (e.g. Escape's 0x1B flushing kernel dead state) is the
-            // clears-preedit-without-committing case, so the canceling
-            // keystroke itself is suppressed. No output at all (arrows,
-            // modifiers, ctrl combos) leaves kernel dead-key state — and
-            // g_composing — untouched.
-            const peeked_char = peekCharForKeydown(hwnd);
+            // spurious keystroke; printables drained alongside the deadchar
+            // are the *previous* composition's commit and are delivered
+            // standalone before the suppressed press. Chars resolve any
+            // pending composition:
+            // a burst ending in a printable is the commit (text attached
+            // below — several codepoints when a failed composition flushes
+            // the accent alongside this key's own char, "´q"); a burst
+            // ending in a control char attaches no text — Enter/Backspace
+            // flushing an accent ("´" then 0x0D) must encode as the key
+            // itself, accent dropped, not have the accent hijack the
+            // encoders' enter/backspace text carve-outs — and when it had
+            // no printables at all (e.g. Escape's 0x1B flushing kernel
+            // dead state) it is the clears-preedit-without-committing
+            // case, so the canceling keystroke itself is suppressed. No
+            // output at all (arrows, modifiers, most ctrl combos) leaves
+            // kernel dead-key state — and g_composing — untouched.
+            const burst = peekCharForKeydown(hwnd);
+            const dead = peekDeadCharForKeydown(hwnd);
             const was_composing = g_composing;
             const composing = cmp: {
-                if (peekDeadCharForKeydown(hwnd)) {
+                if (dead) {
                     g_composing = true;
                     break :cmp true;
                 }
-                if (peeked_char) |peeked| {
+                if (burst.seen > 0) {
                     g_composing = false;
-                    break :cmp was_composing and (peeked < 0x20 or peeked == 0x7f);
+                    break :cmp was_composing and burst.len == 0;
                 }
                 break :cmp g_composing;
             };
 
+            // Dead-then-dead: this keystroke both committed the pending
+            // accent (its WM_CHAR drained into the burst) and started a new
+            // composition (WM_DEADCHAR). Deadchar-wins suppresses the press
+            // below, so the committed printables are delivered first as a
+            // standalone send — composition commits never ride a keycode
+            // (GTK imCommit contract). trailing_control bursts keep today's
+            // never-attach rule.
+            if (dead and burst.len > 0 and !burst.trailing_control) {
+                sendStandaloneText(surface, &g_key_text_buf);
+            }
+
             const has_ctrl = (keyState(.CONTROL) & 0x8000) != 0;
             var consumed_mods: ghostty.ghostty_input_mods_e = ghostty.GHOSTTY_MODS_NONE;
             const text: ?[*]const u8 = txt: {
-                if (peeked_char) |peeked| {
-                    if (peeked >= 0x20 and peeked != 0x7f) {
-                        const cp: u21 = std.math.cast(u21, peeked) orelse break :txt null;
-                        const len = std.unicode.utf8Encode(cp, &g_key_text_buf) catch break :txt null;
-                        if (len < g_key_text_buf.len) {
-                            g_key_text_buf[len] = 0;
-                        }
-                        // Shift/caps were consumed by the OS translation
-                        // only if they actually changed the produced char
-                        // (shift+1 → "!"). If it equals the unshifted
-                        // codepoint (shift+space → " "), claiming
-                        // consumption would strip the modifier and ghostty
-                        // would send plain text instead of a CSI sequence.
-                        if (peeked != unshifted_codepoint) {
-                            consumed_mods = mods & (ghostty.GHOSTTY_MODS_SHIFT | ghostty.GHOSTTY_MODS_CAPS);
-                        }
-                        // Windows reports AltGr as ctrl+alt. Since the key
-                        // produced printable text, strip both so the raw
-                        // ctrl doesn't suppress the encoders' text paths.
-                        const has_alt = (keyState(.MENU) & 0x8000) != 0;
-                        if (has_ctrl and has_alt) {
-                            mods &= ~@as(ghostty.ghostty_input_mods_e, ghostty.GHOSTTY_MODS_CTRL | ghostty.GHOSTTY_MODS_ALT);
-                        }
-                        break :txt &g_key_text_buf;
+                if (burst.len > 0 and !burst.trailing_control and !dead) {
+                    // Shift/caps were consumed by the OS translation only
+                    // if they actually changed the produced char (shift+1
+                    // → "!"). Compare the burst's last codepoint: in a
+                    // flushed burst the leading ones are the previous
+                    // keystroke's accent; only the last is this key's own
+                    // translation. If it equals the unshifted codepoint
+                    // (shift+space → " "), claiming consumption would
+                    // strip the modifier and ghostty would send plain text
+                    // instead of a CSI sequence.
+                    if (burst.last_printable != unshifted_codepoint) {
+                        consumed_mods = mods & (ghostty.GHOSTTY_MODS_SHIFT | ghostty.GHOSTTY_MODS_CAPS);
                     }
-                    // Control chars (e.g. ctrl+A's 0x01) are removed from
-                    // the queue and intentionally dropped — the press
-                    // itself encodes them.
+                    // Windows reports AltGr as ctrl+alt. Since the key
+                    // produced printable text, strip both so the raw
+                    // ctrl doesn't suppress the encoders' text paths.
+                    const has_alt = (keyState(.MENU) & 0x8000) != 0;
+                    if (has_ctrl and has_alt) {
+                        mods &= ~@as(ghostty.ghostty_input_mods_e, ghostty.GHOSTTY_MODS_CTRL | ghostty.GHOSTTY_MODS_ALT);
+                    }
+                    break :txt &g_key_text_buf;
                 }
                 if (!has_ctrl) break :txt null;
                 if (unshifted_codepoint < 0x20) break :txt null;

--- a/runtime/src/platform/windows.zig
+++ b/runtime/src/platform/windows.zig
@@ -507,6 +507,12 @@ var g_pending_text_buf: [5]u8 = undefined;
 var g_key_text_buf: [5]u8 = undefined;
 var g_high_surrogate: u16 = 0;
 
+/// True while the kernel holds a pending dead-key accent (WM_DEADCHAR seen,
+/// commit char not yet produced). Composing events are suppressed by the
+/// encoders — kitty passes only plain modifiers, legacy drops everything —
+/// matching the GTK/AppKit preedit contract.
+var g_composing: bool = false;
+
 // ---------------------------------------------------------------------------
 // Win32 modifier translation
 // ---------------------------------------------------------------------------
@@ -583,6 +589,26 @@ fn peekCharForKeydown(hwnd: HWND) ?u32 {
     return result;
 }
 
+/// Drain the WM_DEADCHAR/WM_SYSDEADCHAR messages queued for the WM_KEYDOWN
+/// currently being dispatched, returning whether any were found. The same
+/// pump-ordering argument as peekCharForKeydown applies. TranslateMessage
+/// posts a deadchar instead of a char when the keystroke starts a dead-key
+/// composition: the kernel holds the pending accent and resolves it on a
+/// later keystroke. The accent codepoints are deliberately not decoded and
+/// not routed through combineSurrogate (which would clobber the shared
+/// g_high_surrogate) — only the fact that a composition started matters.
+fn peekDeadCharForKeydown(hwnd: HWND) bool {
+    var dead = false;
+    var m: wam.MSG = undefined;
+    while (wam.PeekMessageW(&m, hwnd, wam.WM_DEADCHAR, wam.WM_DEADCHAR, wam.PM_REMOVE) != 0) {
+        dead = true;
+    }
+    while (wam.PeekMessageW(&m, hwnd, wam.WM_SYSDEADCHAR, wam.WM_SYSDEADCHAR, wam.PM_REMOVE) != 0) {
+        dead = true;
+    }
+    return dead;
+}
+
 /// Derive the unshifted character for a virtual key code using MapVirtualKeyW.
 /// Returns 0 for non-printable keys. Dead-key bit is masked off.
 fn unshiftedCodepoint(vk_wparam: WPARAM) u32 {
@@ -623,10 +649,36 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
             // (filtered below) or none at all, so we fall through and
             // synthesize printable text. Without text, the legacy encoder
             // drops ctrl+shift+letter events entirely.
+            // Drain this keydown's translation output up front. A deadchar
+            // means the keystroke started a composition (dead press, or a
+            // second dead key restarting one — if a char arrived alongside,
+            // the deadchar wins): the kernel now holds the accent, so the
+            // event must be marked composing or the encoders leak a
+            // spurious keystroke. A char resolves any pending composition:
+            // printable is the commit (text attached below); a control char
+            // (e.g. Escape's 0x1B flushing kernel dead state) is the
+            // clears-preedit-without-committing case, so the canceling
+            // keystroke itself is suppressed. No output at all (arrows,
+            // modifiers, ctrl combos) leaves kernel dead-key state — and
+            // g_composing — untouched.
+            const peeked_char = peekCharForKeydown(hwnd);
+            const was_composing = g_composing;
+            const composing = cmp: {
+                if (peekDeadCharForKeydown(hwnd)) {
+                    g_composing = true;
+                    break :cmp true;
+                }
+                if (peeked_char) |peeked| {
+                    g_composing = false;
+                    break :cmp was_composing and (peeked < 0x20 or peeked == 0x7f);
+                }
+                break :cmp g_composing;
+            };
+
             const has_ctrl = (keyState(.CONTROL) & 0x8000) != 0;
             var consumed_mods: ghostty.ghostty_input_mods_e = ghostty.GHOSTTY_MODS_NONE;
             const text: ?[*]const u8 = txt: {
-                if (peekCharForKeydown(hwnd)) |peeked| {
+                if (peeked_char) |peeked| {
                     if (peeked >= 0x20 and peeked != 0x7f) {
                         const cp: u21 = std.math.cast(u21, peeked) orelse break :txt null;
                         const len = std.unicode.utf8Encode(cp, &g_key_text_buf) catch break :txt null;
@@ -676,7 +728,7 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
                 .keycode = keycode,
                 .text = text,
                 .unshifted_codepoint = unshifted_codepoint,
-                .composing = false,
+                .composing = composing,
             };
 
             g_pending_key_event = null;
@@ -699,7 +751,9 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
                 .keycode = keycode,
                 .text = null,
                 .unshifted_codepoint = unshifted_codepoint,
-                .composing = false,
+                // The dead key's own release lands mid-composition and is
+                // suppressed like its press.
+                .composing = g_composing,
             };
 
             _ = ghostty.ghostty_surface_key(surface, key_event);
@@ -721,6 +775,9 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
             }
 
             key_event.text = &g_pending_text_buf;
+            // An arriving char is a commit: a parked composing press (async
+            // IME) must not be suppressed now that it carries the text.
+            key_event.composing = false;
             // Keep the press-time unshifted_codepoint: overwriting it with
             // the (shifted) WM_CHAR char would corrupt kitty/CSIu key codes.
             _ = ghostty.ghostty_surface_key(surface, key_event);
@@ -793,6 +850,8 @@ fn windowProc(hwnd: HWND, msg: u32, wParam: WPARAM, lParam: LPARAM) callconv(.wi
             return 0;
         },
         wam.WM_KILLFOCUS => {
+            // Focus loss invalidates any in-flight dead-key composition.
+            g_composing = false;
             if (g_surface) |surface| {
                 ghostty.ghostty_surface_set_focus(surface, false);
             }


### PR DESCRIPTION
This addresses a variety of cross-platform issues around dead keys and IMEs, with IMEs still not entirely functional on both Windows and Linux. Fine on MacOS, great OS APIs.
